### PR TITLE
fix(deploy): include .claude/lib in Docker build context

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -11,9 +11,10 @@ RUN corepack enable
 COPY package.json pnpm-lock.yaml ./
 RUN pnpm install --frozen-lockfile
 
-# Copy source and build
+# Copy source and framework lib (persistence types needed by src/)
 COPY tsconfig.json ./
 COPY src/ ./src/
+COPY .claude/lib/ ./.claude/lib/
 RUN pnpm build
 
 # Stage 2: Runtime

--- a/railway.toml
+++ b/railway.toml
@@ -1,0 +1,23 @@
+# deploy/railway.toml — Bridgebuilder cron deployment on Railway
+#
+# Required Railway environment variables:
+#   GITHUB_TOKEN          - GitHub PAT with repo scope
+#   BRIDGEBUILDER_REPOS   - Comma-separated "owner/repo" list
+#   ANTHROPIC_API_KEY     - Anthropic API key for LLM reviews
+#
+# Optional:
+#   BRIDGEBUILDER_MODEL               - Default: claude-sonnet-4-5-20250929
+#   BRIDGEBUILDER_MAX_PRS             - Default: 10
+#   BRIDGEBUILDER_MAX_RUNTIME_MINUTES - Default: 25
+#   BRIDGEBUILDER_DRY_RUN             - Default: false
+#   BRIDGEBUILDER_DIMENSIONS          - Default: security,quality,test-coverage
+#   R2_ENDPOINT, R2_BUCKET, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY - For persistent context
+
+[build]
+  builder = "dockerfile"
+  dockerfilePath = "deploy/Dockerfile"
+
+[deploy]
+  startCommand = "node dist/src/bridgebuilder/entry.js"
+  cronSchedule = "*/30 * * * *"
+  restartPolicyType = "never"


### PR DESCRIPTION
## Summary

- Adds `COPY .claude/lib/ ./.claude/lib/` to the builder stage in `deploy/Dockerfile` — `src/persistence/upstream.ts` imports TypeScript types from `../../.claude/lib/persistence/` which were missing from the build context, causing `pnpm build` to fail on Railway
- Adds `railway.toml` at project root (copy of `deploy/railway.toml`) — Railway requires the config at the repo root for auto-detection

## Test plan

- [x] Verified `pnpm build` succeeds locally
- [x] Deployed to Railway successfully (build time: 36s, status: SUCCESS)
- [x] Bridgebuilder cron service running in dry-run mode

Generated with [Claude Code](https://claude.com/claude-code)