### PR TITLE
fix: exclude .claude/ from vitest in deploy workflows

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -62,7 +62,7 @@ jobs:
         run: npx tsc --noCheck --noEmit
 
       - name: Run tests
-        run: npx vitest run
+        run: npx vitest run --exclude '.claude/**'
 
   # ===========================================================================
   # Docker Build + ECR Push

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,7 +49,7 @@ jobs:
         run: npx tsc --noCheck --noEmit
 
       - name: Run tests
-        run: npx vitest run
+        run: npx vitest run --exclude '.claude/**'
 
   # ===========================================================================
   # Deploy to ECS


### PR DESCRIPTION
## Summary

- Exclude `.claude/**` from `vitest run` in both `deploy-staging.yml` and `deploy.yml`

## Root Cause

`vitest run` (no config) picks up all `**/*.test.ts` including `.claude/skills/bridgebuilder-review/resources/__tests__/schemas.test.ts` which imports `zod/v4` — not in finn's `package.json`. This caused the `Build & Test` job to fail in the deploy workflow triggered after PR #116 merged.

## Test plan

- [ ] CI passes
- [ ] After merge, re-trigger `Deploy to Staging (Armitage)` workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)