### PR TITLE
fix: bump hounfour v8.3.0 → v8.3.1 (domain tag sanitization)

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "postinstall": "bash scripts/build-hounfour-dist.sh"
   },
   "dependencies": {
-    "@0xhoneyjar/loa-hounfour": "github:0xHoneyJar/loa-hounfour#c29337e305005c5de56f8796ba391fb42108b5c5",
+    "@0xhoneyjar/loa-hounfour": "github:0xHoneyJar/loa-hounfour#v8.3.1",
     "@aws-sdk/client-s3": "^3.985.0",
     "@hono/node-server": "^1.19.9",
     "@mariozechner/pi-agent-core": "~0.52.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
   .:
     dependencies:
       '@0xhoneyjar/loa-hounfour':
-        specifier: github:0xHoneyJar/loa-hounfour#c29337e305005c5de56f8796ba391fb42108b5c5
-        version: https://codeload.github.com/0xHoneyJar/loa-hounfour/tar.gz/c29337e305005c5de56f8796ba391fb42108b5c5
+        specifier: github:0xHoneyJar/loa-hounfour#v8.3.1
+        version: https://codeload.github.com/0xHoneyJar/loa-hounfour/tar.gz/aed755f7fea8d2739cf9c755b45aaa580b6af6a9
       '@aws-sdk/client-s3':
         specifier: ^3.985.0
         version: 3.985.0
@@ -133,9 +133,9 @@ importers:
 
 packages:
 
-  '@0xhoneyjar/loa-hounfour@https://codeload.github.com/0xHoneyJar/loa-hounfour/tar.gz/c29337e305005c5de56f8796ba391fb42108b5c5':
-    resolution: {tarball: https://codeload.github.com/0xHoneyJar/loa-hounfour/tar.gz/c29337e305005c5de56f8796ba391fb42108b5c5}
-    version: 8.3.0
+  '@0xhoneyjar/loa-hounfour@https://codeload.github.com/0xHoneyJar/loa-hounfour/tar.gz/aed755f7fea8d2739cf9c755b45aaa580b6af6a9':
+    resolution: {tarball: https://codeload.github.com/0xHoneyJar/loa-hounfour/tar.gz/aed755f7fea8d2739cf9c755b45aaa580b6af6a9}
+    version: 8.3.1
     engines: {node: '>=22'}
 
   '@adraffy/ens-normalize@1.10.1':
@@ -3112,7 +3112,7 @@ packages:
 
 snapshots:
 
-  '@0xhoneyjar/loa-hounfour@https://codeload.github.com/0xHoneyJar/loa-hounfour/tar.gz/c29337e305005c5de56f8796ba391fb42108b5c5':
+  '@0xhoneyjar/loa-hounfour@https://codeload.github.com/0xHoneyJar/loa-hounfour/tar.gz/aed755f7fea8d2739cf9c755b45aaa580b6af6a9':
     dependencies:
       '@noble/hashes': 2.0.1
       '@sinclair/typebox': 0.34.48

--- a/scripts/regenerate-hash-vectors.ts
+++ b/scripts/regenerate-hash-vectors.ts
@@ -14,11 +14,12 @@ import {
   computeChainBoundHash,
   buildDomainTag,
   AUDIT_TRAIL_GENESIS_HASH,
+  computeAdvisoryLockKey,
 } from "../src/hounfour/protocol-types.js"
 import type { AuditEntryHashInput } from "../src/hounfour/protocol-types.js"
 
-const LEGACY_DOMAIN_TAG = buildDomainTag("test-store", "8.3.0")
-const SANITIZED_DOMAIN_TAG = LEGACY_DOMAIN_TAG.replace(/\./g, "-")
+// v8.3.1+: buildDomainTag natively sanitizes dots to hyphens (hounfour PR #42)
+const DOMAIN_TAG = buildDomainTag("test-store", "8.3.1")
 
 const ENTRY_A: AuditEntryHashInput = {
   entry_id: "00000000-0000-0000-0000-000000000001",
@@ -41,17 +42,17 @@ const ENTRY_C: AuditEntryHashInput = {
   payload: { payload_hash: "sha256:cccc" },
 }
 
-const legacyA = computeAuditEntryHash(ENTRY_A, LEGACY_DOMAIN_TAG)
-const legacyB = computeAuditEntryHash(ENTRY_B, LEGACY_DOMAIN_TAG)
-const legacyC = computeAuditEntryHash(ENTRY_C, LEGACY_DOMAIN_TAG)
+const legacyA = computeAuditEntryHash(ENTRY_A, DOMAIN_TAG)
+const legacyB = computeAuditEntryHash(ENTRY_B, DOMAIN_TAG)
+const legacyC = computeAuditEntryHash(ENTRY_C, DOMAIN_TAG)
 
-const chainBoundA = computeChainBoundHash(ENTRY_A, SANITIZED_DOMAIN_TAG, AUDIT_TRAIL_GENESIS_HASH)
-const chainBoundB = computeChainBoundHash(ENTRY_B, SANITIZED_DOMAIN_TAG, chainBoundA)
-const chainBoundC = computeChainBoundHash(ENTRY_C, SANITIZED_DOMAIN_TAG, chainBoundB)
+const chainBoundA = computeChainBoundHash(ENTRY_A, DOMAIN_TAG, AUDIT_TRAIL_GENESIS_HASH)
+const chainBoundB = computeChainBoundHash(ENTRY_B, DOMAIN_TAG, chainBoundA)
+const chainBoundC = computeChainBoundHash(ENTRY_C, DOMAIN_TAG, chainBoundB)
 
 const chainBoundA_tampered = computeChainBoundHash(
   ENTRY_A,
-  SANITIZED_DOMAIN_TAG,
+  DOMAIN_TAG,
   "sha256:0000000000000000000000000000000000000000000000000000000000000000",
 )
 
@@ -64,3 +65,14 @@ console.log(`  chainBoundB: "${chainBoundB}",`)
 console.log(`  chainBoundC: "${chainBoundC}",`)
 console.log(`  chainBoundA_tampered: "${chainBoundA_tampered}",`)
 console.log("} as const")
+
+// Advisory lock key vectors
+const tagTestStore = buildDomainTag("test-store", "8.3.1")
+const tagGovCredits = buildDomainTag("governed-credits", "8.3.1")
+const tagSessions = buildDomainTag("sessions", "8.3.1")
+
+console.log("")
+console.log("// Advisory lock key vectors:")
+console.log(`//   test-store tag: "${tagTestStore}" → ${computeAdvisoryLockKey(tagTestStore)}`)
+console.log(`//   governed-credits tag: "${tagGovCredits}" → ${computeAdvisoryLockKey(tagGovCredits)}`)
+console.log(`//   sessions tag: "${tagSessions}" → ${computeAdvisoryLockKey(tagSessions)}`)

--- a/src/cron/store.ts
+++ b/src/cron/store.ts
@@ -115,7 +115,6 @@ export class AtomicJsonStore<T> {
   private readonly auditEnabled: boolean
   private readonly auditPath: string
   private readonly auditDomainTag: string
-  private readonly auditDomainTagSanitized: string
   private readonly chainBoundHash: boolean
   private auditPrevHash: string = AUDIT_TRAIL_GENESIS_HASH
   private auditEntryCount = 0
@@ -134,13 +133,8 @@ export class AtomicJsonStore<T> {
     this.auditEnabled = options?.auditTrail ?? false
     this.auditPath = filePath + ".audit.jsonl"
     const schemaId = options?.auditSchemaId ?? filenameStem(filePath)
-    const contractVersion = options?.auditContractVersion ?? "8.2.0"
+    const contractVersion = options?.auditContractVersion ?? "8.3.1"
     this.auditDomainTag = buildDomainTag(schemaId, contractVersion)
-    // TODO(hounfour#41): Remove sanitization when upstream fixes impedance.
-    // Chain-bound hash requires validateDomainTag-compliant segments (no dots).
-    // buildDomainTag includes semver (e.g., "8.2.0") which has dots — sanitize
-    // by replacing dots with hyphens for the chain-bound code path. (T-2.3 impedance fix)
-    this.auditDomainTagSanitized = this.auditDomainTag.replace(/\./g, "-")
     this.chainBoundHash = options?.chainBoundHash ?? (process.env.FINN_CHAINBOUND_HASH === "true")
     this.quarantinePath = filePath + ".quarantine.jsonl"
 
@@ -406,13 +400,13 @@ export class AtomicJsonStore<T> {
       payload: { payload_hash: payloadHash },
     }
 
-    // Dual-format hash: chain-bound (v8.3.0) or legacy, per feature flag (Flatline IMP-009)
-    // Chain-bound uses sanitized domain tag (no dots) for validateDomainTag compliance.
+    // Dual-format hash: chain-bound (v8.3.1+) or legacy, per feature flag (Flatline IMP-009)
+    // buildDomainTag() natively sanitizes dots since hounfour v8.3.1 (PR #42).
     let entryHash: string
     let hashAlg: "legacyV1" | "chainBoundV1"
     let domainTagForEntry: string
     if (this.chainBoundHash) {
-      domainTagForEntry = this.auditDomainTagSanitized
+      domainTagForEntry = this.auditDomainTag
       entryHash = computeChainBoundHash(hashInput, domainTagForEntry, this.auditPrevHash)
       hashAlg = "chainBoundV1"
     } else {

--- a/tests/finn/hounfour/chain-bound-hash-vectors.test.ts
+++ b/tests/finn/hounfour/chain-bound-hash-vectors.test.ts
@@ -1,6 +1,6 @@
 // tests/finn/hounfour/chain-bound-hash-vectors.test.ts — T-2.4
 // Hash vector tests for dual-format audit trail (legacy + chain-bound).
-// All expected hex values are hardcoded from canonical hounfour v8.3.0 functions.
+// All expected hex values are hardcoded from canonical hounfour v8.3.1 functions.
 
 import { describe, it, expect } from "vitest"
 import {
@@ -9,17 +9,14 @@ import {
   buildDomainTag,
   AUDIT_TRAIL_GENESIS_HASH,
   computeAdvisoryLockKey,
-  ChainBoundHashError,
   validateDomainTag,
 } from "../../../src/hounfour/protocol-types.js"
 import type { AuditEntryHashInput } from "../../../src/hounfour/protocol-types.js"
 
-// ── Test domain tags ─────────────────────────────────────────────────────
-// buildDomainTag produces "loa-commons:audit:<schemaId>:<version>"
-// Legacy tag has dots in version (valid for computeAuditEntryHash but NOT for computeChainBoundHash).
-// Sanitized tag replaces dots with hyphens for validateDomainTag compliance.
-const LEGACY_DOMAIN_TAG = buildDomainTag("test-store", "8.3.0")
-const SANITIZED_DOMAIN_TAG = LEGACY_DOMAIN_TAG.replace(/\./g, "-")
+// ── Test domain tag ──────────────────────────────────────────────────────
+// v8.3.1+: buildDomainTag natively sanitizes dots to hyphens (hounfour PR #42).
+// No manual sanitization needed — the tag is always validateDomainTag-compliant.
+const DOMAIN_TAG = buildDomainTag("test-store", "8.3.1")
 
 // ── Fixed test entries ───────────────────────────────────────────────────
 
@@ -44,52 +41,36 @@ const ENTRY_C: AuditEntryHashInput = {
   payload: { payload_hash: "sha256:cccc" },
 }
 
-// ── Expected hash values (Golden File Pattern — computed from hounfour v8.3.0) ──
+// ── Expected hash values (Golden File Pattern — computed from hounfour v8.3.1) ──
 //
-// These hex values are hardcoded golden outputs computed from hounfour commit c29337e
-// (v8.3.0 pre-launch hardening). They serve as regression detectors: if hounfour
-// changes its internal hash serialization, these tests will fail, signaling that
-// finn's stored audit trails need migration consideration.
-//
-// This coupling is INTENTIONAL — it's the golden file pattern. The values are NOT
-// derived at test time; they are static fixtures that prove algorithm stability.
+// These hex values are hardcoded golden outputs computed from hounfour v8.3.1
+// (domain tag sanitization fix, PR #42). They serve as regression detectors:
+// if hounfour changes its internal hash serialization, these tests will fail,
+// signaling that finn's stored audit trails need migration consideration.
 //
 // To regenerate after hounfour upgrade:
 //   npx tsx scripts/regenerate-hash-vectors.ts
-//
-// If regenerated values differ from below, it means hounfour changed hash internals.
-// Review the changelog and assess impact on existing stored audit trails before
-// updating these fixtures.
 
 const EXPECTED = {
-  legacyA: "sha256:17f61b10466b6db654fa71eef67856192145c5ac0b56a43597eaf8a4ad698122",
-  legacyB: "sha256:72134e471a51a61ae31676c14017228d38ac3a5ab562dab91cc40f0528e8d2a2",
-  legacyC: "sha256:74cc08686e64520560b385ed3b7d3fc8f6ee4a86e429cd63e7a17764d4600caa",
-  chainBoundA: "sha256:d181547f7639700da6c5208d053df4f91fdfaf57bbb936e18f6eebd2a7654130",
-  chainBoundB: "sha256:e6620938ade641a9abe76eaba98a1e46555aa269a9fd006e76facaaf028e594a",
-  chainBoundC: "sha256:3b274f93de53e0ca2fe801ddb225771ea1bb11e241e11629d08c311a5330aafc",
-  chainBoundA_tampered: "sha256:2be11e39f434692e1ac0312e793936f65527f9cafda1db5a79af2a6e766d3091",
+  legacyA: "sha256:4138f5818cc52a21c48e947575d36dce5f475d604e7c9ed7859c1526ebdb014d",
+  legacyB: "sha256:57c9366c3dda6d88c53a1787b48df36bcc58e3a1fd0137049cc767e9e7fb4300",
+  legacyC: "sha256:763dc9a22cab6a8159f365f1cf2a7b2fddd7d1a7eaa249ec8eb6d0585a8c93a9",
+  chainBoundA: "sha256:10600b194009a43953fd6dfb66e0eca9c7f610e70ec5611d0e1a99bff40815a6",
+  chainBoundB: "sha256:7727a5ba79d4b8526787e60bb5360b0d3bda93579a4062e3d4393c516104a19d",
+  chainBoundC: "sha256:1ad372d1795129158f3d19ab0b6d27bb5f759b0bee5634b30df0435ffbe4c385",
+  chainBoundA_tampered: "sha256:5d14e0a7d0ede8fb504c6c7f953a7f596e7e50727d93292abc9032a191a42b0f",
 } as const
 
 // ── Tests ────────────────────────────────────────────────────────────────
 
 describe("hash vector tests — dual-format audit trail", () => {
   describe("domain tag format", () => {
-    it("buildDomainTag produces expected format", () => {
-      expect(LEGACY_DOMAIN_TAG).toBe("loa-commons:audit:test-store:8.3.0")
+    it("buildDomainTag produces sanitized format (dots → hyphens)", () => {
+      expect(DOMAIN_TAG).toBe("loa-commons:audit:test-store:8-3-1")
     })
 
-    it("sanitized tag replaces dots with hyphens", () => {
-      expect(SANITIZED_DOMAIN_TAG).toBe("loa-commons:audit:test-store:8-3-0")
-    })
-
-    it("validateDomainTag rejects legacy tag (dots in version)", () => {
-      const result = validateDomainTag(LEGACY_DOMAIN_TAG)
-      expect(result.valid).toBe(false)
-    })
-
-    it("validateDomainTag accepts sanitized tag", () => {
-      const result = validateDomainTag(SANITIZED_DOMAIN_TAG)
+    it("validateDomainTag accepts buildDomainTag output", () => {
+      const result = validateDomainTag(DOMAIN_TAG)
       expect(result.valid).toBe(true)
     })
   })
@@ -104,20 +85,20 @@ describe("hash vector tests — dual-format audit trail", () => {
 
   describe("legacy computeAuditEntryHash", () => {
     it("entry A produces expected hash", () => {
-      expect(computeAuditEntryHash(ENTRY_A, LEGACY_DOMAIN_TAG)).toBe(EXPECTED.legacyA)
+      expect(computeAuditEntryHash(ENTRY_A, DOMAIN_TAG)).toBe(EXPECTED.legacyA)
     })
 
     it("entry B produces expected hash", () => {
-      expect(computeAuditEntryHash(ENTRY_B, LEGACY_DOMAIN_TAG)).toBe(EXPECTED.legacyB)
+      expect(computeAuditEntryHash(ENTRY_B, DOMAIN_TAG)).toBe(EXPECTED.legacyB)
     })
 
     it("entry C produces expected hash", () => {
-      expect(computeAuditEntryHash(ENTRY_C, LEGACY_DOMAIN_TAG)).toBe(EXPECTED.legacyC)
+      expect(computeAuditEntryHash(ENTRY_C, DOMAIN_TAG)).toBe(EXPECTED.legacyC)
     })
 
     it("is deterministic (same input → same output)", () => {
-      const h1 = computeAuditEntryHash(ENTRY_A, LEGACY_DOMAIN_TAG)
-      const h2 = computeAuditEntryHash(ENTRY_A, LEGACY_DOMAIN_TAG)
+      const h1 = computeAuditEntryHash(ENTRY_A, DOMAIN_TAG)
+      const h2 = computeAuditEntryHash(ENTRY_A, DOMAIN_TAG)
       expect(h1).toBe(h2)
     })
   })
@@ -125,34 +106,28 @@ describe("hash vector tests — dual-format audit trail", () => {
   describe("chain-bound computeChainBoundHash", () => {
     it("entry A (genesis → A) produces expected hash", () => {
       expect(
-        computeChainBoundHash(ENTRY_A, SANITIZED_DOMAIN_TAG, AUDIT_TRAIL_GENESIS_HASH),
+        computeChainBoundHash(ENTRY_A, DOMAIN_TAG, AUDIT_TRAIL_GENESIS_HASH),
       ).toBe(EXPECTED.chainBoundA)
     })
 
     it("entry B (A → B) produces expected hash", () => {
       expect(
-        computeChainBoundHash(ENTRY_B, SANITIZED_DOMAIN_TAG, EXPECTED.chainBoundA),
+        computeChainBoundHash(ENTRY_B, DOMAIN_TAG, EXPECTED.chainBoundA),
       ).toBe(EXPECTED.chainBoundB)
     })
 
     it("entry C (B → C) produces expected hash", () => {
       expect(
-        computeChainBoundHash(ENTRY_C, SANITIZED_DOMAIN_TAG, EXPECTED.chainBoundB),
+        computeChainBoundHash(ENTRY_C, DOMAIN_TAG, EXPECTED.chainBoundB),
       ).toBe(EXPECTED.chainBoundC)
-    })
-
-    it("rejects legacy domain tag (dots)", () => {
-      expect(() =>
-        computeChainBoundHash(ENTRY_A, LEGACY_DOMAIN_TAG, AUDIT_TRAIL_GENESIS_HASH),
-      ).toThrow(ChainBoundHashError)
     })
   })
 
   describe("3-entry chain integrity", () => {
     it("legacy chain: genesis → A → B → C", () => {
-      const hashA = computeAuditEntryHash(ENTRY_A, LEGACY_DOMAIN_TAG)
-      const hashB = computeAuditEntryHash(ENTRY_B, LEGACY_DOMAIN_TAG)
-      const hashC = computeAuditEntryHash(ENTRY_C, LEGACY_DOMAIN_TAG)
+      const hashA = computeAuditEntryHash(ENTRY_A, DOMAIN_TAG)
+      const hashB = computeAuditEntryHash(ENTRY_B, DOMAIN_TAG)
+      const hashC = computeAuditEntryHash(ENTRY_C, DOMAIN_TAG)
 
       // Legacy hashes are content-only (no chain linkage) — each is independent
       expect(hashA).toBe(EXPECTED.legacyA)
@@ -162,10 +137,10 @@ describe("hash vector tests — dual-format audit trail", () => {
 
     it("chain-bound chain: genesis → A → B → C", () => {
       const hashA = computeChainBoundHash(
-        ENTRY_A, SANITIZED_DOMAIN_TAG, AUDIT_TRAIL_GENESIS_HASH,
+        ENTRY_A, DOMAIN_TAG, AUDIT_TRAIL_GENESIS_HASH,
       )
-      const hashB = computeChainBoundHash(ENTRY_B, SANITIZED_DOMAIN_TAG, hashA)
-      const hashC = computeChainBoundHash(ENTRY_C, SANITIZED_DOMAIN_TAG, hashB)
+      const hashB = computeChainBoundHash(ENTRY_B, DOMAIN_TAG, hashA)
+      const hashC = computeChainBoundHash(ENTRY_C, DOMAIN_TAG, hashB)
 
       expect(hashA).toBe(EXPECTED.chainBoundA)
       expect(hashB).toBe(EXPECTED.chainBoundB)
@@ -177,7 +152,7 @@ describe("hash vector tests — dual-format audit trail", () => {
     it("changing prevHash produces different chain-bound hash", () => {
       const tampered = computeChainBoundHash(
         ENTRY_A,
-        SANITIZED_DOMAIN_TAG,
+        DOMAIN_TAG,
         "sha256:0000000000000000000000000000000000000000000000000000000000000000",
       )
       expect(tampered).toBe(EXPECTED.chainBoundA_tampered)
@@ -187,10 +162,10 @@ describe("hash vector tests — dual-format audit trail", () => {
     it("swapping entry order produces different chain-bound hashes", () => {
       // Chain: genesis → B → A (swapped order)
       const hashB_first = computeChainBoundHash(
-        ENTRY_B, SANITIZED_DOMAIN_TAG, AUDIT_TRAIL_GENESIS_HASH,
+        ENTRY_B, DOMAIN_TAG, AUDIT_TRAIL_GENESIS_HASH,
       )
       const hashA_second = computeChainBoundHash(
-        ENTRY_A, SANITIZED_DOMAIN_TAG, hashB_first,
+        ENTRY_A, DOMAIN_TAG, hashB_first,
       )
 
       // Must differ from normal order (genesis → A → B)
@@ -201,9 +176,9 @@ describe("hash vector tests — dual-format audit trail", () => {
 
   describe("algorithm isolation", () => {
     it("legacy and chain-bound produce different hashes for same entry", () => {
-      const legacy = computeAuditEntryHash(ENTRY_A, LEGACY_DOMAIN_TAG)
+      const legacy = computeAuditEntryHash(ENTRY_A, DOMAIN_TAG)
       const chainBound = computeChainBoundHash(
-        ENTRY_A, SANITIZED_DOMAIN_TAG, AUDIT_TRAIL_GENESIS_HASH,
+        ENTRY_A, DOMAIN_TAG, AUDIT_TRAIL_GENESIS_HASH,
       )
       expect(legacy).not.toBe(chainBound)
     })
@@ -219,21 +194,21 @@ describe("hash vector tests — dual-format audit trail", () => {
 
   describe("advisory lock key vectors", () => {
     it("test-store domain tag → expected key", () => {
-      expect(computeAdvisoryLockKey(LEGACY_DOMAIN_TAG)).toBe(717523562)
+      expect(computeAdvisoryLockKey(DOMAIN_TAG)).toBe(-31603983)
     })
 
     it("governed-credits domain tag → expected key", () => {
-      const tag = buildDomainTag("governed-credits", "8.2.0")
-      expect(computeAdvisoryLockKey(tag)).toBe(-1040989068)
+      const tag = buildDomainTag("governed-credits", "8.3.1")
+      expect(computeAdvisoryLockKey(tag)).toBe(-2057365484)
     })
 
     it("sessions domain tag → expected key", () => {
-      const tag = buildDomainTag("sessions", "8.3.0")
-      expect(computeAdvisoryLockKey(tag)).toBe(1487982359)
+      const tag = buildDomainTag("sessions", "8.3.1")
+      expect(computeAdvisoryLockKey(tag)).toBe(-1806563120)
     })
 
     it("produces signed 32-bit integers", () => {
-      const key = computeAdvisoryLockKey(LEGACY_DOMAIN_TAG)
+      const key = computeAdvisoryLockKey(DOMAIN_TAG)
       expect(key).toBeGreaterThanOrEqual(-2147483648)
       expect(key).toBeLessThanOrEqual(2147483647)
       expect(Number.isInteger(key)).toBe(true)


### PR DESCRIPTION
## Summary
- Bumps `@0xhoneyjar/loa-hounfour` from v8.3.0 to v8.3.1 (domain tag sanitization fix, hounfour PR #42)
- Removes manual dots-to-hyphens workaround in `store.ts` — `buildDomainTag()` now natively sanitizes
- Regenerates all golden hash vectors and advisory lock keys for v8.3.1 domain tags
- All 4681 tests passing (225 files)

## Changes
| File | Change |
|------|--------|
| `package.json` | Pin updated to `#v8.3.1` |
| `src/cron/store.ts` | Removed `auditDomainTagSanitized` field and `.replace()` workaround, bumped default version |
| `scripts/regenerate-hash-vectors.ts` | Unified domain tag, added advisory lock key output |
| `tests/finn/hounfour/chain-bound-hash-vectors.test.ts` | Rewritten for single domain tag, updated all golden values |

Closes #119

## Test plan
- [x] Hash vector tests: 21/21 passing
- [x] Full vitest suite: 4681/4681 passing
- [ ] Build Docker image and deploy to staging ECS

🤖 Generated with [Claude Code](https://claude.com/claude-code)