### PR TITLE
fix(ci): repair deploy ECS action pins + TruffleHog base==head failure

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -117,14 +117,14 @@ jobs:
 
       - name: Update task definition with new image
         id: task-def
-        uses: aws-actions/amazon-ecs-render-task-definition@9666dc9a3bf790a3a7a3a3ce7d1a8600100b0ad2 # v1.7.2
+        uses: aws-actions/amazon-ecs-render-task-definition@e89b6874818d80bb892e7010a5013519bde9d9a6 # v1.7.2
         with:
           task-definition: task-definition.json
           container-name: loa-finn
           image: ${{ steps.build-image.outputs.image }}
 
       - name: Deploy to ECS (rolling update)
-        uses: aws-actions/amazon-ecs-deploy-task-definition@3e7310352de28fdb25b55df7a1dfd15a5ddeb369 # v2.3.1
+        uses: aws-actions/amazon-ecs-deploy-task-definition@176bcc0288c49ee545288583859af21ee17f4b2c # v2.3.1
         with:
           task-definition: ${{ steps.task-def.outputs.task-definition }}
           service: ${{ env.ECS_SERVICE }}

--- a/.github/workflows/secret-scanning.yml
+++ b/.github/workflows/secret-scanning.yml
@@ -33,8 +33,10 @@ jobs:
         uses: trufflesecurity/trufflehog@7f4e37db2d928c18ddd7ddf0604f8f7d1f5793ec # v3.93.0
         with:
           path: ./
-          base: ${{ github.event.repository.default_branch }}
-          head: HEAD
+          # Diff-scan only on PRs (base!=head). On push/schedule, base==head would
+          # abort TruffleHog ("BASE and HEAD are the same"); fall back to a full scan.
+          base: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || '' }}
+          head: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}
           extra_args: --only-verified
 
       - name: Run GitLeaks


### PR DESCRIPTION
## Summary

Two GitHub Actions workflows on `main` fail deterministically on every run. This PR fixes both. No application code changes — CI configuration only.

- **`deploy.yml` (Deploy to ECS):** the `amazon-ecs-render-task-definition` and `amazon-ecs-deploy-task-definition` steps were pinned to commit SHAs that do not exist in the upstream action repos, so the `deploy` job fails immediately at "Set up job" (Actions cannot resolve the ref). The version comments (`# v1.7.2`, `# v2.3.1`) were correct; only the SHAs were wrong/garbled. Re-pinned each to the real commit SHA for the version named in its comment.
  - `amazon-ecs-render-task-definition`: `9666dc9…` → `e89b687…` (real v1.7.2)
  - `amazon-ecs-deploy-task-definition`: `3e73103…` → `176bcc0…` (real v2.3.1)

- **`secret-scanning.yml` (Secret Scanning):** the TruffleHog step set `base: <default_branch>` and `head: HEAD`. On a push to `main` and on the weekly schedule these resolve to the same commit, so TruffleHog aborts with "BASE and HEAD commits are the same. TruffleHog won't scan anything" and exits 1, failing the workflow on every push to main. Scoped the diff-scan to `pull_request` events (where base≠head) and fall back to a full filesystem scan on push/schedule.

## Root cause

- Deploy: the two AWS-action SHAs never matched their version tags — likely hand-edited or copied incorrectly. The other AWS actions in the file (`configure-aws-credentials`, `amazon-ecr-login`) have valid SHAs, which is why only the deploy step failed.
- Secret scanning: TruffleHog's diff mode requires distinct base/head. On a push event there is no PR range, so `default_branch` == `HEAD`.

## Fix

deploy.yml — change only the 40-hex SHA on the two `uses:` lines; comments and indentation untouched.

secret-scanning.yml — TruffleHog `with:` block:
```yaml
          base: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || '' }}
          head: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}
```
PRs still get a precise diff-scan; pushes/schedule get a full-tree scan instead of an abort. `--only-verified` behavior preserved.

## Test / resolution plan

- [x] Both action SHAs verified against `aws-actions/*` tag API to resolve to the named versions (v1.7.2, v2.3.1).
- [x] Both files pass YAML parse + `git diff --check` (no whitespace/conflict markers).
- [ ] Deploy job gets past "Set up job" on the next run to main (verifiable only post-merge).
- [ ] Secret Scanning passes on push to main (no more base==head abort) and still diff-scans PRs.

## Scope

CI workflow files only. No `app/` changes, no dependency changes, no sibling-repo changes.
