### PR TITLE
fix(db): E2E DB bootstrap — finn_migrate schema privileges + idempotent initial migration

### DIFF
--- a/docker-entrypoint-initdb.d/01-finn-roles.sh
+++ b/docker-entrypoint-initdb.d/01-finn-roles.sh
@@ -37,6 +37,13 @@ psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-E
   GRANT ALL ON SCHEMA finn TO finn_migrate;
   GRANT USAGE ON SCHEMA finn TO finn_app;
 
+  -- finn_migrate is the DDL/migration role. Drizzle's migrator creates its own
+  -- "drizzle" bookkeeping schema (CREATE SCHEMA IF NOT EXISTS "drizzle"), which
+  -- requires CREATE on the database: Postgres checks the database-level CREATE
+  -- privilege before the IF NOT EXISTS existence check, so pre-creating the
+  -- schema is not sufficient. Grant CREATE on the database to finn_migrate.
+  GRANT CREATE ON DATABASE finn TO finn_migrate;
+
   -- Default privileges: finn_migrate owns tables, finn_app gets DML
   ALTER DEFAULT PRIVILEGES FOR ROLE finn_migrate IN SCHEMA finn
     GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO finn_app;

--- a/drizzle/0000_productive_titanium_man.sql
+++ b/drizzle/0000_productive_titanium_man.sql
@@ -1,4 +1,4 @@
-CREATE SCHEMA "finn";
+CREATE SCHEMA IF NOT EXISTS "finn";
 --> statement-breakpoint
 CREATE TABLE "finn"."finn_api_keys" (
 	"id" text PRIMARY KEY NOT NULL,


### PR DESCRIPTION
## What this fixes

The **E2E Tests** workflow died at *Build and start services* — the `finn-migrate` step could not run database migrations. Two stacked bugs in the DB bootstrap, both fixed here and verified end-to-end:

**1. Drizzle bookkeeping schema (`961da10`)** — `finn-migrate` runs as the `finn_migrate` role; Drizzle's migrator issues `CREATE SCHEMA IF NOT EXISTS "drizzle"` for its `__drizzle_migrations` table and got `permission denied for database finn`. `01-finn-roles.sh` granted `ALL ON SCHEMA finn` but no privilege to create new schemas, and Postgres checks the database-level `CREATE` privilege *before* the `IF NOT EXISTS` existence check. Fix: `GRANT CREATE ON DATABASE finn TO finn_migrate` (the designated DDL/migration role). `finn_app` stays DML-only.

**2. Initial migration schema collision (`d1e7442`)** — with #1 fixed, the migrator reached migration `0000`, whose first statement `CREATE SCHEMA "finn";` (non-idempotent) collided with the schema the init script already creates → `42P06 schema "finn" already exists`. Fix: `CREATE SCHEMA IF NOT EXISTS "finn"`.

## Verification

Reproduced the exact CI sequence locally (`docker compose -f docker-compose.dev.yml run --rm finn-migrate` against a fresh `down -v` volume):
- Full migration chain runs to `[finn-migrate] migrations complete` (exit 0).
- 6 tables created in `finn` schema, 3 migrations recorded in `drizzle.__drizzle_migrations`.
- Second run is a clean idempotent no-op.
- `finn_app` still cannot create schemas (least-privilege boundary intact).

On CI, this PR turns **`Build and start services` ✓** and **`Wait for finn healthy` ✓** (both previously red/blocked).

## Scope / honest status

This PR fixes **the DB bootstrap only** — the failure this workflow was dying on. It does **not** make the whole E2E *job* green: with bootstrap fixed, the run now advances to `Run E2E tests`, where **17 pre-existing failures** surface that were previously masked (every prior run died before reaching them). Those failures are `connect ECONNREFUSED …:3002` / `fetch failed` — the E2E suite expects sibling services (freeside billing on :3002, dixie reputation, cross-service JWKS exchange) that **this workflow does not provision** (it starts only postgres, redis, finn). That is a separate, structural CI-orchestration concern and should be tracked/fixed on its own, not folded into a DB-bootstrap PR.

Two files, `+8/-1`. No changes to `migrate.ts`, `drizzle.config.ts`, or compose files.