### PR TITLE
feat(gateway): OpenAPI spec augmentation — live invoke/usage/conversation/identity surface (bd-14wv)

### DIFF
--- a/src/gateway/openapi-spec.ts
+++ b/src/gateway/openapi-spec.ts
@@ -669,7 +669,8 @@ export function buildOpenApiSpec(): Record<string, unknown> {
           ],
           responses: {
             "200": {
-              description: "NFTs resolved for wallet",
+              description:
+                "NFTs resolved for wallet. An empty wallet returns { nfts: [] } (not a 404).",
               content: {
                 "application/json": {
                   schema: {
@@ -677,14 +678,10 @@ export function buildOpenApiSpec(): Record<string, unknown> {
                     properties: {
                       nfts: {
                         type: "array",
-                        items: { $ref: "#/components/schemas/NFTInfo" },
-                      },
-                      total: {
-                        type: "integer",
-                        description: "Total number of NFTs found",
+                        items: { $ref: "#/components/schemas/NFTOwnershipInfo" },
                       },
                     },
-                    required: ["nfts", "total"],
+                    required: ["nfts"],
                   },
                 },
               },
@@ -705,6 +702,364 @@ export function buildOpenApiSpec(): Record<string, unknown> {
                 },
               },
             },
+          },
+        },
+      },
+      "/api/identity/wallet/{wallet}/nft": {
+        get: {
+          operationId: "getWalletNft",
+          summary: "Resolve the first NFT for a wallet (deprecated)",
+          description:
+            "Returns only the first NFT held by the given wallet. Deprecated in favor of " +
+            "GET /api/identity/wallet/{wallet}/nfts (RFC 8594). Responses carry Deprecation, " +
+            "Sunset, and Link (successor-version) headers.",
+          tags: ["Identity"],
+          deprecated: true,
+          parameters: [
+            {
+              name: "wallet",
+              in: "path",
+              required: true,
+              schema: { type: "string" },
+              description: "Wallet address (0x...)",
+            },
+          ],
+          responses: {
+            "200": {
+              description: "First NFT for the wallet, or null if none held",
+              headers: {
+                Deprecation: {
+                  description: "RFC 8594 deprecation flag (always \"true\")",
+                  schema: { type: "string" },
+                },
+                Sunset: {
+                  description: "RFC 8594 sunset date for this endpoint",
+                  schema: { type: "string", format: "date-time" },
+                },
+                Link: {
+                  description: "Points to the successor endpoint (rel=successor-version)",
+                  schema: { type: "string" },
+                },
+              },
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      nft: {
+                        oneOf: [
+                          { $ref: "#/components/schemas/NFTInfo" },
+                          { type: "null" },
+                        ],
+                      },
+                    },
+                    required: ["nft"],
+                  },
+                },
+              },
+            },
+            "400": {
+              description: "Invalid wallet address",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/Error" },
+                },
+              },
+            },
+            "502": {
+              description: "NFT resolution upstream failure",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/Error" },
+                },
+              },
+            },
+          },
+        },
+      },
+      // -----------------------------------------------------------------------
+      // Invoke + Usage (tenant-authenticated) — cycle-024 T1/T2
+      // -----------------------------------------------------------------------
+      "/api/v1/invoke": {
+        post: {
+          operationId: "invoke",
+          summary: "Invoke a model for the authenticated tenant",
+          description:
+            "Routes a prompt through pool selection, model routing, and billing finalization for " +
+            "the tenant identified by the JWT. Distinct from /api/v1/x402/invoke (on-chain payment) " +
+            "and /api/v1/agent/chat (personality-conditioned chat).",
+          tags: ["Agent"],
+          security: [{ tenantJwt: [] }],
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/InvokeRequest" },
+              },
+            },
+          },
+          responses: {
+            "200": {
+              description: "Successful invocation",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/InvokeResponse" },
+                },
+              },
+            },
+            "400": {
+              description: "Invalid request body (BINDING_INVALID or missing prompt/agent)",
+              content: {
+                "application/json": { schema: { $ref: "#/components/schemas/Error" } },
+              },
+            },
+            "401": {
+              description: "Missing or invalid tenant JWT",
+              content: {
+                "application/json": { schema: { $ref: "#/components/schemas/Error" } },
+              },
+            },
+            "402": {
+              description: "Budget exceeded (BUDGET_EXCEEDED)",
+              content: {
+                "application/json": { schema: { $ref: "#/components/schemas/Error" } },
+              },
+            },
+            "403": {
+              description: "Knowledge source rejected for security (KNOWLEDGE_INJECTION)",
+              content: {
+                "application/json": { schema: { $ref: "#/components/schemas/Error" } },
+              },
+            },
+            "413": {
+              description: "Context window exceeded (CONTEXT_OVERFLOW)",
+              content: {
+                "application/json": { schema: { $ref: "#/components/schemas/Error" } },
+              },
+            },
+            "422": {
+              description: "Model context window insufficient for knowledge enrichment (ORACLE_MODEL_UNAVAILABLE)",
+              content: {
+                "application/json": { schema: { $ref: "#/components/schemas/Error" } },
+              },
+            },
+            "429": {
+              description: "Rate limit exceeded (RATE_LIMITED)",
+              content: {
+                "application/json": { schema: { $ref: "#/components/schemas/Error" } },
+              },
+            },
+            "502": {
+              description: "Upstream provider unavailable (PROVIDER_UNAVAILABLE)",
+              content: {
+                "application/json": { schema: { $ref: "#/components/schemas/Error" } },
+              },
+            },
+            "503": {
+              description:
+                "Service temporarily unavailable (BUDGET_CIRCUIT_OPEN, ORACLE_KNOWLEDGE_UNAVAILABLE, or billing evaluator degraded)",
+              content: {
+                "application/json": { schema: { $ref: "#/components/schemas/Error" } },
+              },
+            },
+          },
+        },
+      },
+      "/api/v1/usage": {
+        get: {
+          operationId: "getUsage",
+          summary: "Get pre-settlement usage for the authenticated tenant",
+          description:
+            "Returns aggregated, pre-settlement cost-ledger usage for the tenant identified by the " +
+            "JWT, grouped by provider:model. Costs are returned as strings to preserve BigInt precision.",
+          tags: ["Billing"],
+          security: [{ tenantJwt: [] }],
+          parameters: [
+            {
+              name: "days",
+              in: "query",
+              required: false,
+              description: "Lookback window in days (default 7, max 90).",
+              schema: { type: "integer", minimum: 1, maximum: 90, default: 7 },
+            },
+          ],
+          responses: {
+            "200": {
+              description: "Aggregated usage for the tenant",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/UsageResponse" },
+                },
+              },
+            },
+            "400": {
+              description: "Invalid days parameter",
+              content: {
+                "application/json": { schema: { $ref: "#/components/schemas/Error" } },
+              },
+            },
+            "401": {
+              description: "Missing or invalid tenant JWT",
+              content: {
+                "application/json": { schema: { $ref: "#/components/schemas/Error" } },
+              },
+            },
+            "500": {
+              description: "Ledger read error",
+              content: {
+                "application/json": { schema: { $ref: "#/components/schemas/Error" } },
+              },
+            },
+          },
+        },
+      },
+      // -----------------------------------------------------------------------
+      // Conversation CRUD (SIWE session) — message history lifecycle
+      // -----------------------------------------------------------------------
+      "/api/v1/conversations": {
+        post: {
+          operationId: "createConversation",
+          summary: "Create a conversation",
+          description: "Creates a new conversation for an NFT-bound agent. Requires a SIWE session.",
+          tags: ["Conversations"],
+          security: [{ siweSession: [] }],
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    nft_id: {
+                      type: "string",
+                      description: "NFT identifier the conversation is bound to",
+                    },
+                  },
+                  required: ["nft_id"],
+                },
+              },
+            },
+          },
+          responses: {
+            "200": {
+              description: "Conversation created",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/Conversation" },
+                },
+              },
+            },
+            "400": {
+              description: "Invalid request body or missing nft_id",
+              content: {
+                "application/json": { schema: { $ref: "#/components/schemas/Error" } },
+              },
+            },
+            "401": { description: "Authentication required (missing or invalid SIWE session)" },
+            "403": { description: "Access denied to the requested NFT" },
+            "404": { description: "NFT not found" },
+          },
+        },
+        get: {
+          operationId: "listConversations",
+          summary: "List conversations for an NFT",
+          description:
+            "Returns a cursor-paginated list of conversation summaries for an NFT owned by the " +
+            "authenticated wallet.",
+          tags: ["Conversations"],
+          security: [{ siweSession: [] }],
+          parameters: [
+            {
+              name: "nft_id",
+              in: "query",
+              required: true,
+              schema: { type: "string" },
+              description: "NFT identifier to list conversations for",
+            },
+            {
+              name: "cursor",
+              in: "query",
+              required: false,
+              schema: { type: "string" },
+              description: "Opaque pagination cursor from a previous page",
+            },
+            {
+              name: "limit",
+              in: "query",
+              required: false,
+              schema: { type: "integer", minimum: 1, maximum: 50, default: 20 },
+              description: "Page size (default 20, max 50)",
+            },
+          ],
+          responses: {
+            "200": {
+              description: "Paginated conversation summaries",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ConversationSummaryList" },
+                },
+              },
+            },
+            "400": {
+              description: "Missing nft_id or invalid limit",
+              content: {
+                "application/json": { schema: { $ref: "#/components/schemas/Error" } },
+              },
+            },
+            "401": { description: "Authentication required (missing or invalid SIWE session)" },
+          },
+        },
+      },
+      "/api/v1/conversations/{id}/messages": {
+        get: {
+          operationId: "getConversationMessages",
+          summary: "Get messages in a conversation",
+          description:
+            "Returns a cursor-paginated list of messages for a conversation owned by the " +
+            "authenticated wallet.",
+          tags: ["Conversations"],
+          security: [{ siweSession: [] }],
+          parameters: [
+            {
+              name: "id",
+              in: "path",
+              required: true,
+              schema: { type: "string" },
+              description: "Conversation ID",
+            },
+            {
+              name: "cursor",
+              in: "query",
+              required: false,
+              schema: { type: "string" },
+              description: "Opaque pagination cursor from a previous page",
+            },
+            {
+              name: "limit",
+              in: "query",
+              required: false,
+              schema: { type: "integer", minimum: 1, maximum: 50, default: 50 },
+              description: "Page size (default 50, max 50)",
+            },
+          ],
+          responses: {
+            "200": {
+              description: "Paginated conversation messages",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ConversationMessageList" },
+                },
+              },
+            },
+            "400": {
+              description: "Invalid limit",
+              content: {
+                "application/json": { schema: { $ref: "#/components/schemas/Error" } },
+              },
+            },
+            "401": { description: "Authentication required (missing or invalid SIWE session)" },
+            "403": { description: "Access denied to the requested conversation" },
+            "404": { description: "Conversation not found" },
           },
         },
       },
@@ -1063,6 +1418,251 @@ export function buildOpenApiSpec(): Record<string, unknown> {
           },
           required: ["collection", "tokenId", "title"],
         },
+        NFTOwnershipInfo: {
+          type: "object",
+          description:
+            "NFT ownership record aligned with the Dixie NftOwnershipResolver contract " +
+            "(loa-dixie). Returned by GET /api/identity/wallet/{wallet}/nfts.",
+          properties: {
+            nftId: {
+              type: "string",
+              description: "Canonical NFT identifier (collection + tokenId)",
+            },
+            contractAddress: {
+              type: "string",
+              description: "NFT collection contract address",
+            },
+            tokenId: {
+              type: "integer",
+              description: "Token ID within the collection",
+            },
+            ownerWallet: {
+              type: "string",
+              description: "Wallet address that owns the NFT",
+            },
+            delegatedWallets: {
+              type: "array",
+              items: { type: "string" },
+              description: "Wallets delegated access to this NFT (may be empty)",
+            },
+          },
+          required: ["nftId", "contractAddress", "tokenId", "ownerWallet", "delegatedWallets"],
+        },
+        InvokeRequest: {
+          type: "object",
+          description: "Request body for POST /api/v1/invoke",
+          properties: {
+            agent: {
+              type: "string",
+              description: "Agent/binding identifier to route to",
+            },
+            prompt: {
+              type: "string",
+              description: "Non-empty user prompt to send to the agent",
+            },
+          },
+          required: ["agent", "prompt"],
+        },
+        InvokeResponse: {
+          type: "object",
+          description: "Successful response from POST /api/v1/invoke",
+          properties: {
+            response: {
+              type: "string",
+              description: "Agent response text",
+            },
+            model: {
+              type: "string",
+              description: "Model that produced the response",
+            },
+            usage: {
+              type: "object",
+              properties: {
+                prompt_tokens: { type: "integer" },
+                completion_tokens: { type: "integer" },
+                total_tokens: { type: "integer" },
+              },
+              required: ["prompt_tokens", "completion_tokens", "total_tokens"],
+            },
+            cost_micro: {
+              type: "string",
+              description: "Cost of the invocation in micro-USDC (string for precision)",
+            },
+            trace_id: {
+              type: "string",
+              description: "Distributed trace identifier for the invocation",
+            },
+            knowledge: {
+              type: "object",
+              description: "Optional knowledge-enrichment metadata (present only when applicable)",
+            },
+          },
+          required: ["response", "model", "usage", "cost_micro", "trace_id"],
+        },
+        UsageByModel: {
+          type: "object",
+          description: "Per provider:model usage aggregate",
+          properties: {
+            provider: { type: "string" },
+            model: { type: "string" },
+            requests: { type: "integer" },
+            total_cost_micro: {
+              type: "string",
+              description: "Aggregate cost in micro-USDC (string for precision)",
+            },
+            prompt_tokens: { type: "integer" },
+            completion_tokens: { type: "integer" },
+          },
+          required: [
+            "provider",
+            "model",
+            "requests",
+            "total_cost_micro",
+            "prompt_tokens",
+            "completion_tokens",
+          ],
+        },
+        UsageResponse: {
+          type: "object",
+          description: "Pre-settlement usage aggregate for a tenant",
+          properties: {
+            tenant_id: { type: "string" },
+            period: {
+              type: "object",
+              properties: {
+                days: { type: "integer" },
+                from: { type: "string", format: "date-time" },
+                to: { type: "string", format: "date-time" },
+              },
+              required: ["days", "from", "to"],
+            },
+            total_cost_micro: {
+              type: "string",
+              description: "Total cost over the period in micro-USDC (string for precision)",
+            },
+            total_requests: { type: "integer" },
+            by_model: {
+              type: "array",
+              items: { $ref: "#/components/schemas/UsageByModel" },
+            },
+            settlement_status: {
+              type: "string",
+              const: "pre_settlement",
+              description: "Usage is reported before settlement reconciliation",
+            },
+          },
+          required: [
+            "tenant_id",
+            "period",
+            "total_cost_micro",
+            "total_requests",
+            "by_model",
+            "settlement_status",
+          ],
+        },
+        ConversationMessage: {
+          type: "object",
+          description: "A single message within a conversation",
+          properties: {
+            role: { type: "string", enum: ["user", "assistant"] },
+            content: { type: "string" },
+            timestamp: { type: "integer", description: "Unix epoch milliseconds" },
+            cost_cu: {
+              type: "string",
+              description: "Optional cost in credit units for this message",
+            },
+          },
+          required: ["role", "content", "timestamp"],
+        },
+        Conversation: {
+          type: "object",
+          description: "A conversation between a wallet owner and an NFT-bound agent",
+          properties: {
+            id: { type: "string" },
+            nft_id: { type: "string" },
+            owner_address: { type: "string" },
+            messages: {
+              type: "array",
+              items: { $ref: "#/components/schemas/ConversationMessage" },
+            },
+            created_at: { type: "integer", description: "Unix epoch milliseconds" },
+            updated_at: { type: "integer", description: "Unix epoch milliseconds" },
+            message_count: { type: "integer" },
+            snapshot_offset: { type: "integer" },
+            summary: {
+              oneOf: [{ type: "string" }, { type: "null" }],
+              description: "LLM-generated summary of conversation history (may be null)",
+            },
+            summary_message_count: {
+              type: "integer",
+              description: "Message count when the summary was last generated",
+            },
+          },
+          required: [
+            "id",
+            "nft_id",
+            "owner_address",
+            "messages",
+            "created_at",
+            "updated_at",
+            "message_count",
+            "snapshot_offset",
+            "summary",
+            "summary_message_count",
+          ],
+        },
+        ConversationSummary: {
+          type: "object",
+          description: "Lightweight conversation summary returned by the list endpoint",
+          properties: {
+            id: { type: "string" },
+            nft_id: { type: "string" },
+            created_at: { type: "integer", description: "Unix epoch milliseconds" },
+            updated_at: { type: "integer", description: "Unix epoch milliseconds" },
+            message_count: { type: "integer" },
+            last_message_preview: { type: "string" },
+          },
+          required: [
+            "id",
+            "nft_id",
+            "created_at",
+            "updated_at",
+            "message_count",
+            "last_message_preview",
+          ],
+        },
+        ConversationSummaryList: {
+          type: "object",
+          description: "Cursor-paginated list of conversation summaries",
+          properties: {
+            items: {
+              type: "array",
+              items: { $ref: "#/components/schemas/ConversationSummary" },
+            },
+            cursor: {
+              oneOf: [{ type: "string" }, { type: "null" }],
+              description: "Cursor for the next page, or null when there are no more pages",
+            },
+            has_more: { type: "boolean" },
+          },
+          required: ["items", "cursor", "has_more"],
+        },
+        ConversationMessageList: {
+          type: "object",
+          description: "Cursor-paginated list of conversation messages",
+          properties: {
+            items: {
+              type: "array",
+              items: { $ref: "#/components/schemas/ConversationMessage" },
+            },
+            cursor: {
+              oneOf: [{ type: "string" }, { type: "null" }],
+              description: "Cursor for the next page, or null when there are no more pages",
+            },
+            has_more: { type: "boolean" },
+          },
+          required: ["items", "cursor", "has_more"],
+        },
         Error: {
           type: "object",
           properties: {
@@ -1101,6 +1701,14 @@ export function buildOpenApiSpec(): Record<string, unknown> {
           description:
             "Admin JWT with aud: \"loa-finn-admin\" and role: \"admin\". Used for administrative endpoints.",
         },
+        tenantJwt: {
+          type: "http",
+          scheme: "bearer",
+          bearerFormat: "JWT",
+          description:
+            "Tenant JWT (aud: \"loa-finn\") carrying tenant_id and tier claims, issued by the " +
+            "upstream gateway. Required for /api/v1/invoke and /api/v1/usage.",
+        },
       },
     },
     tags: [
@@ -1108,6 +1716,8 @@ export function buildOpenApiSpec(): Record<string, unknown> {
       { name: "Keys", description: "API key lifecycle management" },
       { name: "Auth", description: "SIWE (Sign-In With Ethereum) authentication" },
       { name: "x402", description: "x402 on-chain payment endpoints" },
+      { name: "Conversations", description: "Conversation lifecycle and message history" },
+      { name: "Billing", description: "Usage reporting and pre-settlement cost ledger" },
       { name: "Admin", description: "Administrative endpoints for feature flags and allowlist management" },
       { name: "Identity", description: "NFT identity resolution and wallet-based lookups" },
       { name: "Discovery", description: "Agent discovery and documentation" },

--- a/src/gateway/openapi-spec.ts
+++ b/src/gateway/openapi-spec.ts
@@ -849,6 +849,12 @@ export function buildOpenApiSpec(): Record<string, unknown> {
                 "application/json": { schema: { $ref: "#/components/schemas/Error" } },
               },
             },
+            "500": {
+              description: "Unexpected internal error (INTERNAL_ERROR)",
+              content: {
+                "application/json": { schema: { $ref: "#/components/schemas/Error" } },
+              },
+            },
             "502": {
               description: "Upstream provider unavailable (PROVIDER_UNAVAILABLE)",
               content: {
@@ -900,6 +906,18 @@ export function buildOpenApiSpec(): Record<string, unknown> {
             },
             "401": {
               description: "Missing or invalid tenant JWT",
+              content: {
+                "application/json": { schema: { $ref: "#/components/schemas/Error" } },
+              },
+            },
+            "429": {
+              description: "Rate limit exceeded (RATE_LIMITED). Carries a Retry-After header.",
+              headers: {
+                "Retry-After": {
+                  description: "Seconds to wait before retrying",
+                  schema: { type: "integer" },
+                },
+              },
               content: {
                 "application/json": { schema: { $ref: "#/components/schemas/Error" } },
               },

--- a/src/gateway/routes/usage.ts
+++ b/src/gateway/routes/usage.ts
@@ -90,7 +90,7 @@ export function createUsageHandler(ledgerPath: string) {
         if (!Number.isFinite(tsMs)) continue
         if (tsMs < cutoffMs) continue
 
-        // Extract cost — support both V1 (float USD) and V2 (string micro-USDC)
+        // Extract cost — support both V1 (float USD) and V2 (string micro-USD)
         let costMicro: bigint
         if (entry.schema_version === 2 && typeof entry.total_cost_micro === "string") {
           try {
@@ -99,7 +99,7 @@ export function createUsageHandler(ledgerPath: string) {
             costMicro = 0n
           }
         } else if (typeof entry.total_cost_usd === "number") {
-          // V1: convert float USD to micro-USDC (best-effort)
+          // V1: convert float USD to micro-USD (best-effort)
           costMicro = BigInt(Math.round(entry.total_cost_usd * 1_000_000))
         } else {
           costMicro = 0n

--- a/src/gateway/routes/usage.ts
+++ b/src/gateway/routes/usage.ts
@@ -90,7 +90,7 @@ export function createUsageHandler(ledgerPath: string) {
         if (!Number.isFinite(tsMs)) continue
         if (tsMs < cutoffMs) continue
 
-        // Extract cost — support both V1 (float USD) and V2 (string micro-USD)
+        // Extract cost — support both V1 (float USD) and V2 (string micro-USDC)
         let costMicro: bigint
         if (entry.schema_version === 2 && typeof entry.total_cost_micro === "string") {
           try {
@@ -99,7 +99,7 @@ export function createUsageHandler(ledgerPath: string) {
             costMicro = 0n
           }
         } else if (typeof entry.total_cost_usd === "number") {
-          // V1: convert float USD to micro-USD (best-effort)
+          // V1: convert float USD to micro-USDC (best-effort)
           costMicro = BigInt(Math.round(entry.total_cost_usd * 1_000_000))
         } else {
           costMicro = 0n

--- a/tests/finn/openapi-spec.test.ts
+++ b/tests/finn/openapi-spec.test.ts
@@ -137,6 +137,7 @@ describe("OpenAPI Augmentation (T3.1 · bd-14wv)", () => {
     const responses = invoke.post.responses as Record<string, unknown>
     expect(responses["200"]).toBeDefined()
     expect(responses["402"]).toBeDefined() // BUDGET_EXCEEDED maps to 402
+    expect(responses["500"]).toBeDefined() // unexpected error → INTERNAL_ERROR (routes/invoke.ts)
   })
 
   it("documents the tenant-authenticated GET /api/v1/usage endpoint with days param", () => {
@@ -147,6 +148,8 @@ describe("OpenAPI Augmentation (T3.1 · bd-14wv)", () => {
     expect(security[0]).toHaveProperty("tenantJwt")
     const params = usage.get.parameters as Array<Record<string, unknown>>
     expect(params.some((p) => p.name === "days" && p.in === "query")).toBe(true)
+    // /api/v1/usage passes through rateLimitMiddleware (server.ts) → 429 reachable
+    expect((usage.get.responses as Record<string, unknown>)["429"]).toBeDefined()
   })
 
   it("documents conversation CRUD endpoints under SIWE session auth", () => {

--- a/tests/finn/openapi-spec.test.ts
+++ b/tests/finn/openapi-spec.test.ts
@@ -115,3 +115,111 @@ describe("OpenAPI Specification (T7.1)", () => {
     expect(servers[0].url).toContain("finn.honeyjar.xyz")
   })
 })
+
+// ===========================================================================
+// OpenAPI Augmentation (T3.1 · bd-14wv) — bring the spec in line with the
+// live route surface mounted in server.ts: the tenant-authenticated invoke /
+// usage endpoints, conversation CRUD, and the Dixie-aligned identity shapes.
+// ===========================================================================
+
+describe("OpenAPI Augmentation (T3.1 · bd-14wv)", () => {
+  const spec = buildOpenApiSpec()
+  const paths = spec.paths as Record<string, Record<string, Record<string, unknown>>>
+  const schemas = (spec.components as Record<string, Record<string, unknown>>).schemas as Record<string, Record<string, unknown>>
+  const securitySchemes = (spec.components as Record<string, Record<string, unknown>>).securitySchemes as Record<string, unknown>
+
+  it("documents the tenant-authenticated POST /api/v1/invoke endpoint", () => {
+    const invoke = paths["/api/v1/invoke"]
+    expect(invoke).toBeDefined()
+    expect(invoke.post).toBeDefined()
+    const security = invoke.post.security as Array<Record<string, unknown>>
+    expect(security[0]).toHaveProperty("tenantJwt")
+    const responses = invoke.post.responses as Record<string, unknown>
+    expect(responses["200"]).toBeDefined()
+    expect(responses["402"]).toBeDefined() // BUDGET_EXCEEDED maps to 402
+  })
+
+  it("documents the tenant-authenticated GET /api/v1/usage endpoint with days param", () => {
+    const usage = paths["/api/v1/usage"]
+    expect(usage).toBeDefined()
+    expect(usage.get).toBeDefined()
+    const security = usage.get.security as Array<Record<string, unknown>>
+    expect(security[0]).toHaveProperty("tenantJwt")
+    const params = usage.get.parameters as Array<Record<string, unknown>>
+    expect(params.some((p) => p.name === "days" && p.in === "query")).toBe(true)
+  })
+
+  it("documents conversation CRUD endpoints under SIWE session auth", () => {
+    expect(paths["/api/v1/conversations"]).toBeDefined()
+    expect(paths["/api/v1/conversations"].post).toBeDefined()
+    expect(paths["/api/v1/conversations"].get).toBeDefined()
+    expect(paths["/api/v1/conversations/{id}/messages"]).toBeDefined()
+    expect(paths["/api/v1/conversations/{id}/messages"].get).toBeDefined()
+
+    const createSec = paths["/api/v1/conversations"].post.security as Array<Record<string, unknown>>
+    expect(createSec[0]).toHaveProperty("siweSession")
+  })
+
+  it("documents the deprecated singular identity /nft endpoint (RFC 8594)", () => {
+    const singular = paths["/api/identity/wallet/{wallet}/nft"]
+    expect(singular).toBeDefined()
+    expect(singular.get.deprecated).toBe(true)
+    const ok = (singular.get.responses as Record<string, Record<string, unknown>>)["200"]
+    const headers = ok.headers as Record<string, unknown>
+    expect(headers).toHaveProperty("Deprecation")
+    expect(headers).toHaveProperty("Sunset")
+  })
+
+  it("aligns the plural /nfts response with the Dixie NFTOwnershipInfo shape", () => {
+    const plural = paths["/api/identity/wallet/{wallet}/nfts"]
+    const ok = (plural.get.responses as Record<string, Record<string, unknown>>)["200"]
+    const content = ok.content as Record<string, Record<string, Record<string, unknown>>>
+    const schema = content["application/json"].schema as Record<string, Record<string, unknown>>
+    // No phantom `total` field — the live handler returns only { nfts: [...] }
+    expect(Object.keys(schema.properties)).toEqual(["nfts"])
+    const items = (schema.properties.nfts as Record<string, Record<string, string>>).items
+    expect(items.$ref).toBe("#/components/schemas/NFTOwnershipInfo")
+  })
+
+  it("defines the tenantJwt security scheme", () => {
+    expect(securitySchemes["tenantJwt"]).toBeDefined()
+  })
+
+  it("defines the augmentation component schemas", () => {
+    expect(schemas["InvokeResponse"]).toBeDefined()
+    expect(schemas["UsageResponse"]).toBeDefined()
+    expect(schemas["Conversation"]).toBeDefined()
+    expect(schemas["ConversationSummaryList"]).toBeDefined()
+    expect(schemas["ConversationMessageList"]).toBeDefined()
+    expect(schemas["NFTOwnershipInfo"]).toBeDefined()
+  })
+
+  it("NFTOwnershipInfo carries the Dixie ownership fields", () => {
+    const props = schemas["NFTOwnershipInfo"].properties as Record<string, unknown>
+    expect(props).toHaveProperty("nftId")
+    expect(props).toHaveProperty("contractAddress")
+    expect(props).toHaveProperty("tokenId")
+    expect(props).toHaveProperty("ownerWallet")
+    expect(props).toHaveProperty("delegatedWallets")
+  })
+
+  it("every $ref resolves to a defined component schema (contract integrity)", () => {
+    const refs: string[] = []
+    const walk = (node: unknown): void => {
+      if (Array.isArray(node)) {
+        node.forEach(walk)
+      } else if (node && typeof node === "object") {
+        for (const [k, v] of Object.entries(node as Record<string, unknown>)) {
+          if (k === "$ref" && typeof v === "string") refs.push(v)
+          else walk(v)
+        }
+      }
+    }
+    walk(spec)
+    expect(refs.length).toBeGreaterThan(0)
+    for (const ref of refs) {
+      const name = ref.replace("#/components/schemas/", "")
+      expect(schemas[name], `unresolved $ref: ${ref}`).toBeDefined()
+    }
+  })
+})


### PR DESCRIPTION
## Summary

**bd-14wv · T3.1: OpenAPI Spec Augmentation** (epic bd-e2u9 — Sprint 134: OpenAPI + SDK + Dixie Contracts).

Brings `src/gateway/openapi-spec.ts` in line with the routes **actually mounted in `server.ts`**, so the spec is a faithful contract for the two downstream beads that depend on this one: the TypeScript SDK (bd-1qg7) and the Dixie contract docs (bd-13n6). Every added path/schema is grounded against a live handler I read — nothing speculative.

## What changed

### New paths (grounded against live handlers)
| Path | Method | Auth | Handler |
|------|--------|------|---------|
| `/api/v1/invoke` | POST | tenant JWT | `routes/invoke.ts` |
| `/api/v1/usage` | GET | tenant JWT | `routes/usage.ts` |
| `/api/v1/conversations` | POST, GET | SIWE session | `routes/conversations.ts` |
| `/api/v1/conversations/{id}/messages` | GET | SIWE session | `routes/conversations.ts` |
| `/api/identity/wallet/{wallet}/nft` | GET | public (deprecated, RFC 8594) | `routes/identity.ts` |

### Drift fix
`/api/identity/wallet/{wallet}/nfts` previously documented an `NFTInfo[]` + a `total` field. The live handler returns **`NFTOwnershipInfo[]`** (Dixie-aligned: `nftId` / `contractAddress` / `tokenId` (number) / `ownerWallet` / `delegatedWallets`) and **no `total`**. The spec now matches reality — this is the contract bd-13n6 (Dixie) consumes.

### New components
- Schemas: `NFTOwnershipInfo`, `InvokeRequest`, `InvokeResponse`, `UsageResponse`, `UsageByModel`, `Conversation`, `ConversationMessage`, `ConversationSummary`, `ConversationSummaryList`, `ConversationMessageList`
- Security scheme: `tenantJwt` (Bearer JWT, `aud: loa-finn`)
- Tags: `Conversations`, `Billing`

## Tests
`tests/finn/openapi-spec.test.ts` — new `OpenAPI Augmentation (T3.1 · bd-14wv)` describe block asserting each added path / schema / security scheme, the `/nfts` drift fix, and a **`$ref`-integrity walk** that fails if any `$ref` points to a missing component (guards future drift). Written test-first (red → green).

```
$ vitest run tests/finn/openapi-spec.test.ts
 Test Files  1 passed (1)
      Tests  21 passed (21)
```

## Scope decisions (flagged for review)

Deliberately **excluded** from this augmentation, each for a stated reason — surfacing rather than guessing:

- **`/api/v1/oracle/*`, `/api/v1/score/verdict/{agentId}`** — large, multi-tenant scoring/oracle surface (score-verdict.ts alone is ~35KB). Reads as a separate product contract; documenting it blind risks mis-grounding. Recommend its own task.
- **`/api/v1/admin/mode`, `/api/v1/admin/seed-credits`** — internal admin ops beyond the feature-flags/allowlist already documented.
- **`/api/sessions*`, `/health*` variants, `/dashboard`, `/onboarding`, `/.well-known/jwks.json`, `/api/v1/public`** — operational/internal/UI, not part of the consumer SDK contract. (`/public` and `jwks.json` are public and could be added later if the SDK needs them.)
- **`/api/v1/credits/*`** — `creditRoutes` is exported from `src/credits/routes.ts` but **never imported/mounted** anywhere. Documenting it would be a phantom endpoint, so it's omitted.

**Assumption flagged:** bd-14wv carries no AC list (terse bead, no sprint-134 design doc in grimoires). I inferred "augmentation" = make the spec faithful to the live consumer-facing surface that the SDK + Dixie docs wrap. If the intent was the full route surface (incl. oracle/score), that's a follow-up.

### Pre-existing state (not introduced here)
`tsc --noEmit` reports 46 errors on `origin/main` (jose 6.x dropped `KeyLike`, viem version drift, billing/payment-decision) — **0** in the files this PR touches. `git diff --name-only origin/main` = exactly these 2 files.

### bd-3f5l (Sprint 60: Knowledge Engine Foundation) — assessed, skipped
Not greenfield: all four core modules already exist (`src/hounfour/knowledge-{types,loader,registry,enricher}.ts`) and the first child (bd-6rdc, Knowledge Types) is **CLOSED**. No clean first-increment to add without re-doing closed work; left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)