### PR TITLE
[codex] Add Eileen daily implementation agent runbook

### DIFF
--- a/eileendailyimplementationagentmodeagent.md
+++ b/eileendailyimplementationagentmodeagent.md
@@ -1,0 +1,104 @@
+# Eileen Daily Implementation Agent Mode Agent
+
+This file is the repo-local runbook for the daily GPT-5.5 Thinking implementation agent. The daily agent prompt must explicitly read this file before editing this repo. This file is intentionally separate from `AGENTS.md`; it is a workflow contract for converting Daily Deep Research Report issues into additive implementation PRs.
+
+## Repository responsibility
+
+`0xHoneyJar/loa-finn` owns deterministic experiments and runtime measurement: preregistered SHA-pinned experiments, no-LLM scoring, runtime audit trails, WAL/event sourcing, sandboxing, cost metering, and agent-commerce forensics.
+
+This repo is not the place for Freeside product behavior, Straylight estate doctrine, Dixie API ownership, Hounfour package schemas, Aleph research-précis doctrine, or Arcturus proof-of-revenue oracle logic.
+
+## Eligible input
+
+Only implement from a Daily Deep Research Report issue or follow-up plan-audit issue/comment that contains:
+
+- `PROPOSED_NEXT_LANE_SEED`
+- candidate ID
+- repo-fit reasoning
+- acceptance criteria
+- rollback path
+- `VERDICT: ACCEPT_PLAN`
+
+If the candidate lacks `VERDICT: ACCEPT_PLAN`, the agent may perform in-run plan audit only for docs, fixtures, tests, or checkers. Runtime/evaluation semantics require explicit external acceptance.
+
+## Selection rule
+
+Pick at most one candidate per run. Prefer work that improves experiment reproducibility, deterministic scoring evidence, cost/correctness measurement, or falsification coverage.
+
+Priority order:
+
+1. docs-only experiment preregistration
+2. fixture-only datasets or traces
+3. test-only deterministic coverage
+4. checker/validator-only additions
+5. default-off measurement helpers
+
+## Additive-only policy
+
+Nothing currently working may stop functioning.
+
+Allowed by default:
+
+- new docs
+- new preregistration templates
+- new fixtures
+- new tests
+- new deterministic checkers
+- default-off experiment harness helpers
+
+Forbidden without explicit Eileen approval:
+
+- deleting files
+- changing scoring semantics by default
+- replacing deterministic verdicts with LLM judgment
+- changing WAL/runtime behavior by default
+- production migrations
+- broad refactors
+- unrelated dependency upgrades
+- secrets or real env changes
+- sibling repo mutation
+- deployment changes
+- auto-merge
+- closing source issues
+
+## Finn-specific stop conditions
+
+Stop and return `VERDICT: NEEDS_HUMAN` if the candidate would:
+
+- turn an experiment into a product/economy claim
+- alter `HELD`, `FALSIFIED`, or `INSUFFICIENT` semantics
+- introduce non-deterministic scoring in the score core
+- weaken audit trails, cost metering, sandboxing, or WAL/event evidence
+- change runtime behavior without an explicit experiment gate
+
+## Implementation steps
+
+1. Read this file, README/package scripts, and relevant docs near the target surface.
+2. Inspect the source issue and confirm `VERDICT: ACCEPT_PLAN`.
+3. Check for obvious duplicate open issues/PRs.
+4. Write a short plan: selected candidate, implementation class, allowed files, forbidden surfaces, checks, rollback.
+5. Create a branch named `daily-impl/YYYY-MM-DD-loa-finn-<candidate>`.
+6. Implement exactly one candidate with a minimal diff.
+7. Run relevant checks from the repo.
+8. Open a draft PR.
+9. Add `CODEX AUDIT REQUEST` to the PR body.
+10. Comment: `@codex review for additive-only scope violations, deterministic-scoring regressions, accidental runtime behavior changes, failing or missing tests, rollback clarity, repo-boundary violations, and security regressions`.
+11. Do not merge and do not close the source issue.
+
+## PR body requirements
+
+The PR must include:
+
+- source issue
+- candidate ID
+- implementation class
+- what changed
+- what did not change
+- checks run
+- skipped or failing checks
+- rollback path
+- Codex audit request
+
+## Final run report
+
+Report the selected repo, source issue, branch, PR URL, files changed, checks run, Codex review status, blockers, and whether any boundary was approached.

--- a/eileendailyimplementationagentmodeagent.md
+++ b/eileendailyimplementationagentmodeagent.md
@@ -1,6 +1,6 @@
 # Eileen Daily Implementation Agent Mode Agent
 
-This file is the repo-local runbook for the daily GPT-5.5 Thinking implementation agent. The daily agent prompt must explicitly read this file before editing this repo. This file is intentionally separate from `AGENTS.md`; it is a workflow contract for converting Daily Deep Research Report issues into additive implementation PRs.
+This is the repo-local runbook for the daily GPT-5.5 Thinking implementation agent. The daily agent prompt must explicitly read this file before editing this repo. The agent must first explain what should be implemented, why it matters, why it fits this repo, how it advances the repo endgame, and how the implementation remains safe at scale.
 
 ## Repository responsibility
 
@@ -10,95 +10,61 @@ This repo is not the place for Freeside product behavior, Straylight estate doct
 
 ## Eligible input
 
-Only implement from a Daily Deep Research Report issue or follow-up plan-audit issue/comment that contains:
+Only implement from a Daily Deep Research Report issue or follow-up plan-audit item with `PROPOSED_NEXT_LANE_SEED`, candidate ID, repo-fit reasoning, acceptance criteria, rollback path, and `VERDICT: ACCEPT_PLAN`.
 
-- `PROPOSED_NEXT_LANE_SEED`
-- candidate ID
-- repo-fit reasoning
-- acceptance criteria
-- rollback path
-- `VERDICT: ACCEPT_PLAN`
+Without `VERDICT: ACCEPT_PLAN`, the agent may self-audit only docs, fixtures, tests, or checkers. Runtime/evaluation semantics require explicit external acceptance.
 
-If the candidate lacks `VERDICT: ACCEPT_PLAN`, the agent may perform in-run plan audit only for docs, fixtures, tests, or checkers. Runtime/evaluation semantics require explicit external acceptance.
+## Mandatory pre-implementation thesis
 
-## Selection rule
+Before editing, write this in the run log and later carry it into the PR body:
 
-Pick at most one candidate per run. Prefer work that improves experiment reproducibility, deterministic scoring evidence, cost/correctness measurement, or falsification coverage.
+1. Candidate chosen: issue, candidate ID, and verdict.
+2. What should be implemented: precise change, not a vague theme.
+3. Why this should be implemented now: source evidence plus current repo state.
+4. Why this belongs in `loa-finn`: repo-fit and why sibling repos should not own it.
+5. What this is good for: reproducibility, falsification, cost/correctness evidence, or runtime audit quality.
+6. Why this approach should work: deterministic mechanism, expected evidence, and proof path.
+7. Endgame contribution: how this moves Finn toward a better agent-commerce experiment and runtime truth substrate.
+8. Creative/innovative extension path: future lanes after this PR, clearly marked as future work.
+9. Mass-user scaling impact: experiment volume, data size, runtime cost, WAL growth, sandbox load, and measurement overhead.
+10. Security scope: sandbox boundaries, trace integrity, prompt/model isolation, cost abuse, and evidence tampering risks.
+11. Simplification / exploit-prevention argument: how the change avoids non-determinism and fragile hidden behavior.
+12. Non-goals and forbidden surfaces.
+13. Tests/checks and rollback path.
 
-Priority order:
-
-1. docs-only experiment preregistration
-2. fixture-only datasets or traces
-3. test-only deterministic coverage
-4. checker/validator-only additions
-5. default-off measurement helpers
+If the agent cannot complete this thesis convincingly, it must not implement.
 
 ## Additive-only policy
 
 Nothing currently working may stop functioning.
 
-Allowed by default:
+Allowed by default: new docs, preregistration templates, fixtures, tests, deterministic checkers, and default-off experiment harness helpers.
 
-- new docs
-- new preregistration templates
-- new fixtures
-- new tests
-- new deterministic checkers
-- default-off experiment harness helpers
-
-Forbidden without explicit Eileen approval:
-
-- deleting files
-- changing scoring semantics by default
-- replacing deterministic verdicts with LLM judgment
-- changing WAL/runtime behavior by default
-- production migrations
-- broad refactors
-- unrelated dependency upgrades
-- secrets or real env changes
-- sibling repo mutation
-- deployment changes
-- auto-merge
-- closing source issues
+Forbidden without explicit Eileen approval: deleting files, changing scoring semantics by default, replacing deterministic verdicts with LLM judgment, changing WAL/runtime behavior by default, production migrations, broad refactors, unrelated dependency upgrades, secrets or real env changes, sibling repo mutation, deployment changes, auto-merge, or closing source issues.
 
 ## Finn-specific stop conditions
 
-Stop and return `VERDICT: NEEDS_HUMAN` if the candidate would:
-
-- turn an experiment into a product/economy claim
-- alter `HELD`, `FALSIFIED`, or `INSUFFICIENT` semantics
-- introduce non-deterministic scoring in the score core
-- weaken audit trails, cost metering, sandboxing, or WAL/event evidence
-- change runtime behavior without an explicit experiment gate
+Stop and return `VERDICT: NEEDS_HUMAN` if the candidate would turn an experiment into a product/economy claim, alter `HELD`, `FALSIFIED`, or `INSUFFICIENT` semantics, introduce non-deterministic scoring in the score core, weaken audit trails/cost metering/sandboxing/WAL evidence, or change runtime behavior without an explicit experiment gate.
 
 ## Implementation steps
 
 1. Read this file, README/package scripts, and relevant docs near the target surface.
-2. Inspect the source issue and confirm `VERDICT: ACCEPT_PLAN`.
+2. Confirm the source item has `VERDICT: ACCEPT_PLAN`.
 3. Check for obvious duplicate open issues/PRs.
-4. Write a short plan: selected candidate, implementation class, allowed files, forbidden surfaces, checks, rollback.
+4. Write the mandatory pre-implementation thesis.
 5. Create a branch named `daily-impl/YYYY-MM-DD-loa-finn-<candidate>`.
 6. Implement exactly one candidate with a minimal diff.
-7. Run relevant checks from the repo.
-8. Open a draft PR.
-9. Add `CODEX AUDIT REQUEST` to the PR body.
-10. Comment: `@codex review for additive-only scope violations, deterministic-scoring regressions, accidental runtime behavior changes, failing or missing tests, rollback clarity, repo-boundary violations, and security regressions`.
-11. Do not merge and do not close the source issue.
+7. Prefer simpler deterministic logic and explicit checks over clever abstractions.
+8. Run relevant checks.
+9. Open a draft PR.
+10. Add `CODEX AUDIT REQUEST` and the required traceability report.
+11. Comment: `@codex review for additive-only scope violations, deterministic-scoring regressions, accidental runtime behavior changes, scaling risks, security regressions, exploit-prone complexity, failing or missing tests, rollback clarity, and repo-boundary violations`.
+12. Do not merge and do not close the source issue.
 
-## PR body requirements
+## Required PR traceability report
 
-The PR must include:
-
-- source issue
-- candidate ID
-- implementation class
-- what changed
-- what did not change
-- checks run
-- skipped or failing checks
-- rollback path
-- Codex audit request
+Every implementation PR must include source issue and candidate ID, pre-implementation thesis summary, what changed with file-by-file rationale, why each changed file is good for this repo, why it advances the repo endgame, why it should work, mass-user scaling analysis, security scope and exploit-prevention analysis, simplicity analysis, tests/checks, skipped checks, rollback path, future creative/innovative solution paths not implemented, and `CODEX AUDIT REQUEST`.
 
 ## Final run report
 
-Report the selected repo, source issue, branch, PR URL, files changed, checks run, Codex review status, blockers, and whether any boundary was approached.
+Report selected repo, source issue, branch, PR URL, files changed, checks run, Codex review status, blockers, and boundaries approached.


### PR DESCRIPTION
## Summary

Adds top-level `eileendailyimplementationagentmodeagent.md` as the repo-local runbook for the daily GPT-5.5 Thinking implementation agent.

## Scope

Docs-only. This does not change runtime behavior, package files, tests, or CI.

## Why

The daily implementation agent needs a durable repo-local file that explains how to convert Daily Deep Research Report issues into one additive PR while preserving this repo's boundaries.

## Validation

Not run; docs-only runbook addition.

## Notes

This file is intentionally separate from `AGENTS.md`. The daily agent-mode prompt should explicitly read `eileendailyimplementationagentmodeagent.md` before editing this repo.

No Codex review was triggered automatically.