### PR TITLE
[codex] Make clock drift checks injectable

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test:bridgebuilder": "tsx tests/finn/bridgebuilder-r2-context.test.ts && tsx tests/finn/bridgebuilder-launch.test.ts",
     "test:billing": "vitest run tests/finn/billing-finalize.test.ts tests/finn/protocol-handshake.test.ts",
     "test:gateway": "vitest run tests/finn/invoke-handler.test.ts tests/finn/usage-handler.test.ts tests/finn/invoke-billing-path.test.ts tests/finn/otlp-tracing.test.ts",
+    "test:time-provider": "vitest run tests/gateway/time-provider.test.ts",
     "test:microbench": "vitest run tests/finn/billing-microbench.test.ts",
     "test:e2e": "vitest run --config vitest.config.e2e.ts",
     "test:x402": "vitest run tests/x402/",

--- a/src/gateway/time-provider.ts
+++ b/src/gateway/time-provider.ts
@@ -67,6 +67,8 @@ export class MockTimeProvider implements TimeProvider {
 export interface ClockDriftConfig {
   /** Maximum acceptable drift in milliseconds (default: 1000) */
   maxDriftMs?: number
+  /** Optional injected time source; defaults to the system clock */
+  timeProvider?: TimeProvider
   /** Callback when drift is detected */
   onDrift?: (driftMs: number) => void
 }
@@ -96,7 +98,7 @@ export function measureClockDrift(
   config: ClockDriftConfig = {},
 ): ClockDriftResult {
   const maxDriftMs = config.maxDriftMs ?? 1000
-  const systemMs = Date.now()
+  const systemMs = config.timeProvider?.now() ?? Date.now()
   const driftMs = Math.abs(systemMs - referenceTimeMs)
   const withinTolerance = driftMs <= maxDriftMs
 

--- a/tests/gateway/time-provider.test.ts
+++ b/tests/gateway/time-provider.test.ts
@@ -111,6 +111,37 @@ describe("measureClockDrift", () => {
     expect(result.referenceMs).toBe(ref)
     expect(result.systemMs).toBeGreaterThan(0)
   })
+
+  it("uses an injected provider for exact deterministic drift", () => {
+    const provider = new MockTimeProvider(10_000)
+    const result = measureClockDrift(8_500, {
+      maxDriftMs: 2_000,
+      timeProvider: provider,
+    })
+
+    expect(result.systemMs).toBe(10_000)
+    expect(result.referenceMs).toBe(8_500)
+    expect(result.driftMs).toBe(1_500)
+    expect(result.withinTolerance).toBe(true)
+  })
+
+  it("passes exact injected-clock drift to onDrift", () => {
+    const provider = new MockTimeProvider(20_000)
+    let driftValue = 0
+
+    const result = measureClockDrift(16_250, {
+      maxDriftMs: 1_000,
+      timeProvider: provider,
+      onDrift: (drift) => {
+        driftValue = drift
+      },
+    })
+
+    expect(result.systemMs).toBe(20_000)
+    expect(result.driftMs).toBe(3_750)
+    expect(result.withinTolerance).toBe(false)
+    expect(driftValue).toBe(3_750)
+  })
 })
 
 describe("defaultTimeProvider", () => {


### PR DESCRIPTION
## Summary

Refs #246.

Makes Finn's `measureClockDrift()` helper use the same `TimeProvider` abstraction already defined in `src/gateway/time-provider.ts`.

## What changed

- Adds optional `ClockDriftConfig.timeProvider`.
- Falls back to `Date.now()` when no provider is supplied, preserving current call sites.
- Adds deterministic `MockTimeProvider` drift tests with exact `systemMs`, `driftMs`, and callback assertions.
- Adds `npm run test:time-provider` / `pnpm test:time-provider` as a targeted validation script for this module.

## Why

The module already documents `TimeProvider` as the abstraction for clock skew monitoring and testing, but drift measurement still read wall-clock time directly. That made future SIWE/x402/TTL boundary wiring harder to validate deterministically.

## Validation

Not run locally in this connector-only pass. Expected targeted check:

```bash
pnpm test:time-provider
```

## Connector-safety notes

Small TypeScript/test/package-script change only. No security workflows, payment handlers, SQL migrations, large server files, or broad route refactors touched.

## Non-claims

This PR does not add production NTP checks and does not wire SIWE, x402, or receipt verification to drift enforcement.