### PR TITLE
[codex] Surface E2E target coverage in test output

### DIFF
--- a/tests/e2e/full-flow.test.ts
+++ b/tests/e2e/full-flow.test.ts
@@ -13,6 +13,10 @@ import { resolve } from "node:path"
 const FINN_URL = process.env.E2E_FINN_URL ?? "http://localhost:3001"
 const FREESIDE_URL = process.env.E2E_FREESIDE_URL ?? "http://localhost:3002"
 const DIXIE_URL = process.env.E2E_DIXIE_URL ?? "http://localhost:3003"
+const HAS_EXPLICIT_FREESIDE_TARGET = Boolean(process.env.E2E_FREESIDE_URL?.trim())
+const HAS_EXPLICIT_DIXIE_TARGET = Boolean(process.env.E2E_DIXIE_URL?.trim())
+const describeWhenFreesideConfigured = HAS_EXPLICIT_FREESIDE_TARGET ? describe : describe.skip
+const describeWhenDixieConfigured = HAS_EXPLICIT_DIXIE_TARGET ? describe : describe.skip
 
 const KEYS_DIR = resolve(import.meta.dirname ?? __dirname, "keys")
 
@@ -47,31 +51,36 @@ describe("E2E: Full Flow Integration (three-leg)", () => {
       .sign(adminPrivateKey)
   }
 
-  describe("three-leg health verification", () => {
-    it("all three services are healthy", async () => {
-      // Finn liveness
+  describe("health verification", () => {
+    it("finn is healthy", async () => {
       const finnRes = await fetch(`${FINN_URL}/healthz`, {
         signal: AbortSignal.timeout(5000),
       })
       expect(finnRes.status).toBe(200)
-
-      // Freeside health
-      const freesideRes = await fetch(`${FREESIDE_URL}/v1/health`, {
-        signal: AbortSignal.timeout(5000),
-      })
-      expect(freesideRes.status).toBe(200)
-
-      // Dixie health (may have different path)
-      const dixieRes = await fetch(`${DIXIE_URL}/health`, {
-        signal: AbortSignal.timeout(5000),
-      }).catch(() => null)
-
-      if (dixieRes) {
-        expect([200, 404]).toContain(dixieRes.status)
-      }
     })
 
-    it("finn readiness includes all dependencies", async () => {
+    describeWhenFreesideConfigured("freeside health — requires E2E_FREESIDE_URL", () => {
+      it("freeside is healthy", async () => {
+        const freesideRes = await fetch(`${FREESIDE_URL}/v1/health`, {
+          signal: AbortSignal.timeout(5000),
+        })
+        expect(freesideRes.status).toBe(200)
+      })
+    })
+
+    describeWhenDixieConfigured("dixie health — requires E2E_DIXIE_URL", () => {
+      it("dixie is reachable", async () => {
+        const dixieRes = await fetch(`${DIXIE_URL}/health`, {
+          signal: AbortSignal.timeout(5000),
+        }).catch(() => null)
+
+        if (dixieRes) {
+          expect([200, 404]).toContain(dixieRes.status)
+        }
+      })
+    })
+
+    it("finn readiness includes local dependencies", async () => {
       const res = await fetch(`${FINN_URL}/health/deps`, {
         signal: AbortSignal.timeout(5000),
       })
@@ -91,47 +100,51 @@ describe("E2E: Full Flow Integration (three-leg)", () => {
   })
 
   describe("inference → billing → reputation flow", () => {
-    it("finn processes request with billing integration", async () => {
-      // Seed credits via admin endpoint so billing flow has funds
-      const authToken = process.env.FINN_AUTH_TOKEN
-      if (authToken) {
-        await fetch(`${FINN_URL}/api/v1/admin/seed-credits`, {
-          method: "POST",
-          headers: {
-            Authorization: `Bearer ${authToken}`,
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({
-            wallet_address: "0x00000000000000000000000000000000deadbeef",
-            credits: 10000,
-          }),
+    describeWhenFreesideConfigured("billing integration — requires E2E_FREESIDE_URL", () => {
+      it("finn processes request with billing integration", async () => {
+        // Seed credits via admin endpoint so billing flow has funds
+        const authToken = process.env.FINN_AUTH_TOKEN
+        if (authToken) {
+          await fetch(`${FINN_URL}/api/v1/admin/seed-credits`, {
+            method: "POST",
+            headers: {
+              Authorization: `Bearer ${authToken}`,
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              wallet_address: "0x00000000000000000000000000000000deadbeef",
+              credits: 10000,
+            }),
+            signal: AbortSignal.timeout(5000),
+          })
+        }
+
+        // Verify freeside billing endpoint is reachable from our test harness
+        const freesideHealth = await fetch(`${FREESIDE_URL}/v1/health`, {
           signal: AbortSignal.timeout(5000),
         })
-      }
-
-      // Verify freeside billing endpoint is reachable from our test harness
-      const freesideHealth = await fetch(`${FREESIDE_URL}/v1/health`, {
-        signal: AbortSignal.timeout(5000),
+        expect(freesideHealth.status).toBe(200)
       })
-      expect(freesideHealth.status).toBe(200)
     })
 
-    it("reputation query returns data or null gracefully", async () => {
-      // Direct reputation query to dixie
-      const res = await fetch(`${DIXIE_URL}/reputation/nft-test-001`, {
-        headers: { Accept: "application/json" },
-        signal: AbortSignal.timeout(5000),
-      }).catch(() => null)
+    describeWhenDixieConfigured("reputation query — requires E2E_DIXIE_URL", () => {
+      it("reputation query returns data or null gracefully", async () => {
+        // Direct reputation query to dixie
+        const res = await fetch(`${DIXIE_URL}/reputation/nft-test-001`, {
+          headers: { Accept: "application/json" },
+          signal: AbortSignal.timeout(5000),
+        }).catch(() => null)
 
-      if (res && res.status === 200) {
-        const body = await res.json() as Record<string, unknown>
-        // ReputationResponse shape: { score, version, ... }
-        if (typeof body.score === "number") {
-          expect(body.score).toBeGreaterThanOrEqual(0)
-          expect(body.score).toBeLessThanOrEqual(1)
+        if (res && res.status === 200) {
+          const body = await res.json() as Record<string, unknown>
+          // ReputationResponse shape: { score, version, ... }
+          if (typeof body.score === "number") {
+            expect(body.score).toBeGreaterThanOrEqual(0)
+            expect(body.score).toBeLessThanOrEqual(1)
+          }
         }
-      }
-      // 404 or connection error = no reputation data yet (acceptable)
+        // 404 or connection error = no reputation data yet (acceptable)
+      })
     })
   })
 

--- a/tests/e2e/jwt-exchange.test.ts
+++ b/tests/e2e/jwt-exchange.test.ts
@@ -15,6 +15,10 @@ import { resolve } from "node:path"
 const FINN_URL = process.env.E2E_FINN_URL ?? "http://localhost:3001"
 const FREESIDE_URL = process.env.E2E_FREESIDE_URL ?? "http://localhost:3002"
 const DIXIE_URL = process.env.E2E_DIXIE_URL ?? "http://localhost:3003"
+const HAS_EXPLICIT_FREESIDE_TARGET = Boolean(process.env.E2E_FREESIDE_URL?.trim())
+const HAS_EXPLICIT_DIXIE_TARGET = Boolean(process.env.E2E_DIXIE_URL?.trim())
+const describeWhenFreesideConfigured = HAS_EXPLICIT_FREESIDE_TARGET ? describe : describe.skip
+const describeWhenDixieConfigured = HAS_EXPLICIT_DIXIE_TARGET ? describe : describe.skip
 
 const KEYS_DIR = resolve(import.meta.dirname ?? __dirname, "keys")
 
@@ -54,7 +58,7 @@ describe("E2E: JWT Exchange (three-leg)", () => {
     })
   })
 
-  describe("finn → freeside (billing JWT)", () => {
+  describeWhenFreesideConfigured("finn → freeside (billing JWT) — requires E2E_FREESIDE_URL", () => {
     it("finn-signed JWT is accepted by freeside billing endpoint", async () => {
       // Sign a billing JWT as finn
       const token = await new SignJWT({
@@ -80,7 +84,7 @@ describe("E2E: JWT Exchange (three-leg)", () => {
     })
   })
 
-  describe("finn → dixie (reputation query)", () => {
+  describeWhenDixieConfigured("finn → dixie (reputation query) — requires E2E_DIXIE_URL", () => {
     it("finn can query dixie reputation endpoint", async () => {
       // Query dixie reputation (may return 404 for unknown NFT — that's fine)
       const res = await fetch(`${DIXIE_URL}/reputation/nft-test-001`, {
@@ -91,7 +95,9 @@ describe("E2E: JWT Exchange (three-leg)", () => {
       // Dixie is up and responding (200 or 404 both valid)
       expect([200, 404]).toContain(res.status)
     })
+  })
 
+  describe("finn-signed JWT shape", () => {
     it("finn-signed JWT can be verified against finn JWKS", async () => {
       // Step 1: Finn signs a JWT
       const token = await new SignJWT({

--- a/tests/e2e/target-coverage.test.ts
+++ b/tests/e2e/target-coverage.test.ts
@@ -1,0 +1,44 @@
+// tests/e2e/target-coverage.test.ts — visible three-service target coverage
+//
+// This intentionally does not prove Freeside/Dixie behavior by itself. It makes
+// the selected service targets explicit in E2E output so Finn-only/default-target
+// runs are not mistaken for externally configured three-service evidence.
+
+import { describe, expect, it } from "vitest"
+
+type TargetStatus = {
+  service: "finn" | "freeside" | "dixie"
+  envName: string
+  url: string
+  source: "env" | "default"
+}
+
+function resolveTarget(service: TargetStatus["service"], envName: string, fallbackUrl: string): TargetStatus {
+  const configured = process.env[envName]?.trim()
+
+  return {
+    service,
+    envName,
+    url: configured && configured.length > 0 ? configured : fallbackUrl,
+    source: configured && configured.length > 0 ? "env" : "default",
+  }
+}
+
+function targetSummary(target: TargetStatus): string {
+  return `${target.service}: ${target.url} (${target.envName}=${target.source})`
+}
+
+describe("E2E target coverage visibility", () => {
+  it("prints whether each three-service target came from env or the local default", () => {
+    const targets = [
+      resolveTarget("finn", "E2E_FINN_URL", "http://localhost:3001"),
+      resolveTarget("freeside", "E2E_FREESIDE_URL", "http://localhost:3002"),
+      resolveTarget("dixie", "E2E_DIXIE_URL", "http://localhost:3003"),
+    ]
+
+    console.info(`[e2e-targets] ${targets.map(targetSummary).join("; ")}`)
+
+    expect(targets.map((target) => target.service)).toEqual(["finn", "freeside", "dixie"])
+    expect(targets.every((target) => target.url.length > 0)).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

Refs #242.

Makes optional three-service E2E coverage explicit instead of silent/default-ambiguous.

## Why

Issue #242 calls out that Finn-only/default-target E2E evidence can be mistaken for externally configured three-service coverage. This patch makes target selection visible and makes Freeside/Dixie-dependent suites visibly skipped unless their explicit `E2E_*_URL` values are provided.

## What changed

- Adds `tests/e2e/target-coverage.test.ts`.
- Emits a single `[e2e-targets] ...` line showing `finn`, `freeside`, and `dixie` target URL plus `env` vs `default` source.
- Updates `tests/e2e/jwt-exchange.test.ts` so Freeside/Dixie-dependent suites use named `describe.skip` paths when `E2E_FREESIDE_URL` / `E2E_DIXIE_URL` are absent.
- Updates `tests/e2e/full-flow.test.ts` with the same visible Freeside/Dixie suite gating while keeping Finn-only health/readiness/metrics/admin checks running.

## Safety / non-claims

- Test files only.
- No runtime code changes.
- No workflow, scanner, audit threshold, dependency, lockfile, payment/HMAC, or SQL changes.
- This improves visibility; it does not claim the remaining repo-global audit/security/E2E startup failures are fixed.

## Validation

Connector verification fetched the committed files on this branch and confirmed:

- `[e2e-targets]` output remains present in `tests/e2e/target-coverage.test.ts`.
- `tests/e2e/jwt-exchange.test.ts` has named Freeside/Dixie `describe.skip` gates.
- `tests/e2e/full-flow.test.ts` has named Freeside/Dixie `describe.skip` gates and Finn-only checks outside those gates.