### PR TITLE
fix(build): make fresh-install tsc build green — 44 errors, incl. 4 runtime bugs

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -52,11 +52,12 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      # Type check: --noCheck matches Dockerfile behavior (viem type drift
-      # causes ~29 pre-existing TS errors that don't affect runtime).
-      # Strict type checking runs in ci.yml.
-      - name: Compile check
-        run: npx tsc --noCheck --noEmit
+      # Strict type check: the pre-existing TS errors that forced --noCheck
+      # (viem/jose type drift + real call-shape bugs) were fixed in issue
+      # #154's cleanup; this now guards against new drift since no other
+      # workflow runs tsc.
+      - name: Type check
+        run: npx tsc --noEmit
 
       - name: Run tests
         run: npx vitest run

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,11 +42,12 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      # Type check: --noCheck matches Dockerfile behavior (viem type drift
-      # causes ~29 pre-existing TS errors that don't affect runtime).
-      # Strict type checking runs in ci.yml.
-      - name: Compile check
-        run: npx tsc --noCheck --noEmit
+      # Strict type check: the pre-existing TS errors that forced --noCheck
+      # (viem/jose type drift + real call-shape bugs) were fixed in issue
+      # #154's cleanup; this now guards against new drift since no other
+      # workflow runs tsc.
+      - name: Type check
+        run: npx tsc --noEmit
 
       - name: Run tests
         run: npx vitest run

--- a/src/billing/dlq.ts
+++ b/src/billing/dlq.ts
@@ -160,7 +160,9 @@ export class DLQProcessor {
       for (const { streamId, entry } of entries) {
         result.processed++
 
-        const attempt = parseInt(entry.attempt, 10) || 0
+        // Redis stream fields arrive as strings at runtime even though the
+        // interface declares number — normalize before parsing.
+        const attempt = parseInt(String(entry.attempt), 10) || 0
 
         // Check for poison message (max retries exceeded)
         if (attempt >= MAX_DLQ_RETRIES) {

--- a/src/boot/secrets.ts
+++ b/src/boot/secrets.ts
@@ -62,7 +62,7 @@ export class SecretsLoader {
 
     console.log(JSON.stringify({
       metric: "secrets.loaded",
-      fields: Object.keys(secrets).filter(k => !!(secrets as Record<string, unknown>)[k]).length,
+      fields: Object.keys(secrets).filter(k => !!(secrets as unknown as Record<string, unknown>)[k]).length,
       required_ok: true,
       timestamp: Date.now(),
     }))

--- a/src/gateway/payment-decision.ts
+++ b/src/gateway/payment-decision.ts
@@ -167,7 +167,7 @@ async function handleApiKeyPath(
   // Get request cost
   const body = await peekJsonBody(c)
   const amountMicro = parseInt(
-    getRequestCost(body?.token_id ?? "", body?.model ?? "", body?.max_tokens ?? 0),
+    getRequestCost(bodyStr(body, "token_id"), bodyStr(body, "model"), bodyNum(body, "max_tokens")),
     10,
   )
 
@@ -261,9 +261,9 @@ async function handleX402Path(
 
   // Parse request body for binding parameters
   const body = await peekJsonBody(c)
-  const tokenId = body?.token_id ?? ""
-  const model = body?.model ?? ""
-  const maxTokens = body?.max_tokens ?? 0
+  const tokenId = bodyStr(body, "token_id")
+  const model = bodyStr(body, "model")
+  const maxTokens = bodyNum(body, "max_tokens")
 
   try {
     const receipt = await deps.receiptVerifier.verify({
@@ -328,9 +328,9 @@ async function issueChallenge(
 
   // Parse body to get binding parameters
   const body = await peekJsonBody(c)
-  const tokenId = body?.token_id ?? ""
-  const model = body?.model ?? ""
-  const maxTokens = body?.max_tokens ?? 0
+  const tokenId = bodyStr(body, "token_id")
+  const model = bodyStr(body, "model")
+  const maxTokens = bodyNum(body, "max_tokens")
 
   try {
     const challenge = await deps.challengeIssuer.issue({
@@ -394,4 +394,16 @@ async function peekJsonBody(
   } catch {
     return null
   }
+}
+
+/** Narrow an untrusted body field to string ('' when absent or mistyped). */
+function bodyStr(body: Record<string, unknown> | null, key: string): string {
+  const v = body?.[key]
+  return typeof v === "string" ? v : ""
+}
+
+/** Narrow an untrusted body field to number (0 when absent or mistyped). */
+function bodyNum(body: Record<string, unknown> | null, key: string): number {
+  const v = body?.[key]
+  return typeof v === "number" ? v : 0
 }

--- a/src/gateway/siwe-ownership.ts
+++ b/src/gateway/siwe-ownership.ts
@@ -64,7 +64,7 @@ export function clearOwnerCache(): void {
 
 export interface OwnershipMiddlewareConfig {
   /** JWT public key for verifying access tokens */
-  jwtPublicKey: jose.KeyLike | Uint8Array
+  jwtPublicKey: CryptoKey | Uint8Array
   /** JWT algorithm (default: ES256) */
   jwtAlgorithm?: string
 }

--- a/src/gateway/wallet-auth.ts
+++ b/src/gateway/wallet-auth.ts
@@ -8,7 +8,7 @@ import { randomBytes, createHash } from "node:crypto"
 import { Hono } from "hono"
 import * as jose from "jose"
 import { SiweMessage } from "siwe"
-import { createPublicClient, http, getAddress, type PublicClient, type Hex } from "viem"
+import { createPublicClient, http, getAddress, type HttpTransport, type PublicClient, type Hex } from "viem"
 import { base } from "viem/chains"
 import { RateLimiter } from "./rate-limit.js"
 
@@ -28,9 +28,9 @@ export interface WalletAuthConfig {
   /** Allowed origins for CSRF */
   allowedOrigins: string[]
   /** JWT signing key (ES256 private key PEM or JWK) */
-  jwtPrivateKey: jose.KeyLike | Uint8Array
+  jwtPrivateKey: CryptoKey | Uint8Array
   /** JWT verification key (ES256 public key) */
-  jwtPublicKey: jose.KeyLike | Uint8Array
+  jwtPublicKey: CryptoKey | Uint8Array
   /** Access token TTL in seconds (default: 900 = 15min) */
   accessTokenTtlSec?: number
   /** Refresh token TTL in seconds (default: 86400 = 24h) */
@@ -70,7 +70,9 @@ const EIP_1271_MAGIC_VALUE = "0x1626ba7e"
 // ---------------------------------------------------------------------------
 
 export class WalletAuthService {
-  private client: PublicClient
+  // Typed with the OP-Stack `base` chain: its extended block/transaction
+  // formatters make the client incompatible with the bare PublicClient type.
+  private client: PublicClient<HttpTransport, typeof base>
   private nonceRateLimiter: RateLimiter
   private purchaseRateLimiter: RateLimiter
   private config: Required<Pick<WalletAuthConfig, "accessTokenTtlSec" | "refreshTokenTtlSec">> & WalletAuthConfig

--- a/src/gateway/x402-routes.ts
+++ b/src/gateway/x402-routes.ts
@@ -13,7 +13,7 @@ import type { SettlementService } from "../x402/settlement.js"
 import type { CreditNoteService } from "../x402/credit-note.js"
 import type { AllowlistService } from "./allowlist.js"
 import type { FeatureFlagService } from "./feature-flags.js"
-import { X402Error, X402_RATE_LIMIT_PER_HOUR } from "../x402/types.js"
+import { X402Error, X402_RATE_LIMIT_PER_HOUR, type PaymentProof } from "../x402/types.js"
 
 // ---------------------------------------------------------------------------
 // Types
@@ -166,7 +166,10 @@ export function createX402InvokeHandler(deps: X402RouteDeps) {
 
     // 8. Verify payment
     try {
-      const verification = await deps.paymentVerifier.verify(proof, quote)
+      // The header is parsed loosely (quote_id + authorization.from checked
+      // above); PaymentVerifier.verify performs the full structural and
+      // signature validation, so the boundary cast is safe.
+      const verification = await deps.paymentVerifier.verify(proof as unknown as PaymentProof, quote)
 
       // 9. Settle payment
       if (!verification.idempotent_replay) {

--- a/src/hounfour/goodhart/read-only-redis.ts
+++ b/src/hounfour/goodhart/read-only-redis.ts
@@ -25,7 +25,7 @@ export function createReadOnlyRedisClient(redis: RedisCommandClient): RedisComma
 
       // Allow read methods to pass through
       if (READ_METHODS.has(prop)) {
-        const method = (target as Record<string, unknown>)[prop]
+        const method = (target as unknown as Record<string, unknown>)[prop]
         if (typeof method === "function") {
           return method.bind(target)
         }
@@ -38,7 +38,7 @@ export function createReadOnlyRedisClient(redis: RedisCommandClient): RedisComma
       }
 
       // Block all other functions (mutating methods) with rejected Promise (T-7.1)
-      const value = (target as Record<string, unknown>)[prop]
+      const value = (target as unknown as Record<string, unknown>)[prop]
       if (typeof value === "function") {
         return () => Promise.reject(new Error(`Redis writes blocked in shadow mode (attempted: ${prop})`))
       }

--- a/src/hounfour/infra/prefixed-redis.ts
+++ b/src/hounfour/infra/prefixed-redis.ts
@@ -53,7 +53,7 @@ export async function createPrefixedRedisClient(
         return (target as any)[prop]
       }
 
-      const value = (target as Record<string, unknown>)[prop]
+      const value = (target as unknown as Record<string, unknown>)[prop]
 
       if (typeof value !== "function") {
         return value

--- a/src/hounfour/jwt-auth.ts
+++ b/src/hounfour/jwt-auth.ts
@@ -69,6 +69,10 @@ export const AUDIENCE_MAP = {
   invoke: "loa-finn",
   admin: "loa-finn-admin",
   s2s: "arrakis",
+  // BYOK requests ride the invoke surface (BYOK-ness is the `byok` claims
+  // flag, not a separate audience); resolveAudience("byok") previously fell
+  // through to undefined.
+  byok: "loa-finn",
 } as const
 
 export type EndpointType = "invoke" | "admin" | "s2s" | "byok"

--- a/src/hounfour/pool-enforcement.ts
+++ b/src/hounfour/pool-enforcement.ts
@@ -267,7 +267,7 @@ export function evaluateAccessPolicyShadow(
   mode: AccessPolicyEnforcementMode = ACCESS_POLICY_ENFORCEMENT_MODE,
 ): boolean {
   // No access_policy in claims → no protocol evaluation, pass through
-  const accessPolicy = (claims as Record<string, unknown>).access_policy
+  const accessPolicy = (claims as unknown as Record<string, unknown>).access_policy
   if (accessPolicy == null) return localAllowed
 
   // Build protocol context from JWT claims

--- a/src/hounfour/router.ts
+++ b/src/hounfour/router.ts
@@ -273,7 +273,7 @@ export class HounfourRouter {
     circuitBreakerStates: Map<import("@0xhoneyjar/loa-hounfour").PoolId, "closed" | "half-open" | "open">,
     poolCosts: Map<import("@0xhoneyjar/loa-hounfour").PoolId, number>,
     defaultPoolCost: number,
-    poolCapabilities: Map<import("@0xhoneyjar/loa-hounfour").PoolId, Set<import("../nft-routing-config.js").NFTRoutingKey>>,
+    poolCapabilities: Map<import("@0xhoneyjar/loa-hounfour").PoolId, Set<import("./nft-routing-config.js").NFTRoutingKey>>,
     requestId: string,
   ): Promise<{ pool: import("@0xhoneyjar/loa-hounfour").PoolId; source: "deterministic" | "reputation" | "shadow" }> {
     const startMs = Date.now()

--- a/src/index.ts
+++ b/src/index.ts
@@ -302,11 +302,11 @@ async function main() {
           initDeps,
           (recovered) => {
             goodhartRuntime.goodhartConfig = recovered.goodhartConfig
-            goodhartRuntime.routingState = recovered.routingState as RoutingState
+            goodhartRuntime.routingState = recovered.routingState as import("./hounfour/router.js").RoutingState
             goodhartRuntime.goodhartMetrics = recovered.goodhartMetrics
             goodhartRuntime.runtimeConfig = recovered.runtimeConfig
             goodhartConfig = recovered.goodhartConfig
-            routingState = recovered.routingState as RoutingState
+            routingState = recovered.routingState as import("./hounfour/router.js").RoutingState
             goodhartMetrics = recovered.goodhartMetrics
             console.log(`[finn] goodhart recovered: routing state now ${recovered.routingState}`)
           },
@@ -658,12 +658,13 @@ async function main() {
 
       if (hounfour) {
         const synthRouter = {
+          // HounfourRouter.invoke is (agent, prompt, options) — the agent
+          // binding resolves the model; the previous object-form call threw
+          // BINDING_INVALID at runtime whenever hounfour was enabled.
           invoke: async (agent: string, prompt: string, options?: { temperature?: number; max_tokens?: number }) => {
-            const result = await hounfour.invoke({
-              messages: [{ role: "user", content: prompt }],
-              model: "claude-opus-4-6",
+            const result = await hounfour.invoke(agent, prompt, {
               temperature: options?.temperature ?? 0.7,
-              maxTokens: options?.max_tokens ?? 2048,
+              max_tokens: options?.max_tokens ?? 2048,
             })
             return { content: result.content ?? "" }
           },
@@ -718,11 +719,11 @@ async function main() {
             personalityProvider: pipeline,
             generateResponse: async (systemPrompt: string, userMessage: string) => {
               if (!hounfour) throw new Error("Hounfour not available")
-              const result = await hounfour.invoke({
-                messages: [
-                  { role: "system", content: systemPrompt },
-                  { role: "user", content: userMessage },
-                ],
+              // Same binding the synthesis path uses; the persona rides in
+              // via InvokeOptions.systemPrompt (injected as the first
+              // system message by the router).
+              const result = await hounfour.invoke("beauvoir-synth", userMessage, {
+                systemPrompt,
               })
               return result.content ?? ""
             },

--- a/src/nft/chain-config.ts
+++ b/src/nft/chain-config.ts
@@ -4,7 +4,7 @@
 // EthersOwnershipProvider uses viem for on-chain ERC-721 ownerOf() calls.
 // MockOwnershipProvider for CI/test environments — deterministic, no network.
 
-import { createPublicClient, http, getAddress, type PublicClient } from "viem"
+import { createPublicClient, http, getAddress, type HttpTransport, type PublicClient } from "viem"
 import { base } from "viem/chains"
 
 // ---------------------------------------------------------------------------
@@ -73,7 +73,8 @@ export interface EthersOwnershipProviderConfig {
 }
 
 export class EthersOwnershipProvider implements OwnershipProvider {
-  private client: PublicClient
+  // OP-Stack `base` chain formatters require the instantiated generic.
+  private client: PublicClient<HttpTransport, typeof base>
   private transferCallbacks: Array<(from: string, to: string, tokenId: string) => void> = []
 
   constructor(config?: EthersOwnershipProviderConfig) {

--- a/src/nft/entropy.ts
+++ b/src/nft/entropy.ts
@@ -569,7 +569,8 @@ export function ceremonyRoutes(deps: CeremonyRouteDeps): Hono {
   // POST /api/v1/nft/:collection/:tokenId/ceremony/commit
   app.post("/:collection/:tokenId/ceremony/commit", async (c) => {
     const { collection, tokenId } = c.req.param()
-    const walletAddress: string = c.get("wallet_address") ?? "unknown"
+    const walletAddressVar: unknown = c.get("wallet_address")
+    const walletAddress: string = typeof walletAddressVar === "string" ? walletAddressVar : "unknown"
 
     let body: unknown
     try {
@@ -615,7 +616,8 @@ export function ceremonyRoutes(deps: CeremonyRouteDeps): Hono {
   // POST /api/v1/nft/:collection/:tokenId/ceremony/reveal
   app.post("/:collection/:tokenId/ceremony/reveal", async (c) => {
     const { collection, tokenId } = c.req.param()
-    const walletAddress: string = c.get("wallet_address") ?? "unknown"
+    const walletAddressVar: unknown = c.get("wallet_address")
+    const walletAddress: string = typeof walletAddressVar === "string" ? walletAddressVar : "unknown"
 
     let body: unknown
     try {

--- a/src/nft/ownership.ts
+++ b/src/nft/ownership.ts
@@ -3,7 +3,7 @@
 // ERC-721 ownerOf() check via Base RPC (viem). Cached 5 minutes.
 // Fail-closed: RPC failures deny access with 503.
 
-import { createPublicClient, http, getAddress, type PublicClient } from "viem"
+import { createPublicClient, http, getAddress, type HttpTransport, type PublicClient } from "viem"
 import { base } from "viem/chains"
 
 // ---------------------------------------------------------------------------
@@ -61,8 +61,9 @@ interface CacheEntry {
 }
 
 export class OwnershipService {
-  private primaryClient: PublicClient
-  private fallbackClient: PublicClient | null
+  // OP-Stack `base` chain formatters require the instantiated generic.
+  private primaryClient: PublicClient<HttpTransport, typeof base>
+  private fallbackClient: PublicClient<HttpTransport, typeof base> | null
   private collections: Set<string>
   private cache: Map<string, CacheEntry>
 
@@ -141,7 +142,7 @@ export class OwnershipService {
     }
   }
 
-  private async callOwnerOf(client: PublicClient, collection: string, tokenId: string): Promise<string> {
+  private async callOwnerOf(client: PublicClient<HttpTransport, typeof base>, collection: string, tokenId: string): Promise<string> {
     const owner = await client.readContract({
       address: getAddress(collection) as `0x${string}`,
       abi: ERC721_ABI,

--- a/src/nft/personality-pipeline.ts
+++ b/src/nft/personality-pipeline.ts
@@ -7,7 +7,9 @@
 // Includes: singleflight lock (SKP-004), dual-write consistency (SKP-003),
 // BEAUVOIR sanitization (SKP-008), and fallback degradation (FR-7).
 
-import type { Redis as RedisClient } from "ioredis"
+// The narrowed command interface (what redis.getClient() actually returns);
+// the pipeline only uses set/eval/exists.
+import type { RedisCommandClient as RedisClient } from "../hounfour/redis/client.js"
 import type { PersonalityProvider, PersonalityConfig } from "./personality-provider.js"
 import type { SignalCache } from "./signal-cache.js"
 import type { BeauvoirSynthesizer, IdentitySubgraph } from "./beauvoir-synthesizer.js"

--- a/src/nft/transfer-listener.ts
+++ b/src/nft/transfer-listener.ts
@@ -68,7 +68,7 @@ export class TransferListener {
   private readonly collection: string
   private readonly config: Required<
     Pick<TransferListenerConfig, "maxBackoffMs" | "baseBackoffMs" | "maxRetries">
-  > & Pick<TransferListenerConfig, "onTransfer" | "onError" | "onReconnect">
+  > & Pick<TransferListenerConfig, "onTransfer" | "onError" | "onReconnect" | "onTransferInvalidate">
 
   private unwatch: WatchContractEventReturnType | null = null
   private running = false
@@ -91,6 +91,9 @@ export class TransferListener {
       onTransfer: config?.onTransfer,
       onError: config?.onError,
       onReconnect: config?.onReconnect,
+      // Was silently dropped here — the Cycle 040 cache-invalidation hook
+      // never fired even when configured.
+      onTransferInvalidate: config?.onTransferInvalidate,
     }
   }
 

--- a/src/substrate/__tests__/model-runner-layer.integration.test.ts
+++ b/src/substrate/__tests__/model-runner-layer.integration.test.ts
@@ -95,7 +95,9 @@ describe.skipIf(!constructAvailable)(
       }
 
       const program = constructModule.gradeLoreEssay(input)
-      const result = (await Effect.runPromise(program.pipe(Effect.provide(layer as never)))) as {
+      const result = (await Effect.runPromise(
+        program.pipe(Effect.provide(layer as never)) as Effect.Effect<unknown, unknown, never>,
+      )) as {
         status: string
         confidence: number
         graderConstructSlug?: string
@@ -134,12 +136,14 @@ describe.skipIf(!constructAvailable)(
       }
 
       const program = constructModule.gradeLoreEssay(input)
-      const exit = await Effect.runPromiseExit(program.pipe(Effect.provide(failingLayer as never)))
+      const exit = await Effect.runPromiseExit(
+        program.pipe(Effect.provide(failingLayer as never)) as Effect.Effect<unknown, unknown, never>,
+      )
 
       expect(exit._tag).toBe("Failure")
       // The construct should have received the loader-emitted ModelRunnerError
       // (its grader.ts pattern-matches on ModelRunnerError._tag)
-      const causeStr = JSON.stringify(exit.cause)
+      const causeStr = exit._tag === "Failure" ? JSON.stringify(exit.cause) : ""
       expect(causeStr).toContain("ModelRunnerError")
     })
 

--- a/src/substrate/__tests__/model-runner-layer.test.ts
+++ b/src/substrate/__tests__/model-runner-layer.test.ts
@@ -51,7 +51,7 @@ describe("buildModelRunnerLayer", () => {
   })
 
   it("translates {systemPrompt, userMessage} into a CompletionRequest", async () => {
-    const spy = vi.fn(async () => makeCannedResult("ok"))
+    const spy = vi.fn(async (_req: CompletionRequest) => makeCannedResult("ok"))
     const invoker = makeMockInvoker(spy)
     const layer = buildModelRunnerLayer({
       invoker,
@@ -114,7 +114,7 @@ describe("buildModelRunnerLayer", () => {
   })
 
   it("uses default max_tokens=4096 and temperature=0.2 when not provided", async () => {
-    const spy = vi.fn(async () => makeCannedResult("x"))
+    const spy = vi.fn(async (_req: CompletionRequest) => makeCannedResult("x"))
     const layer = buildModelRunnerLayer({
       invoker: { complete: spy },
       modelId: "m",


### PR DESCRIPTION
## Summary

`pnpm run build` (bare `tsc`) failed on a fresh clone with 44 TypeScript errors (issue #154 reported 35; main drifted further because no workflow runs a real `tsc` — the deploy workflows use `tsc --noCheck --noEmit`, which only parses, and their comment claims strict checking runs in ci.yml, which it never did). This PR makes `tsc` fully green and ratchets CI so it stays green.

Four of the errors were masking **real runtime bugs**:

1. **`src/index.ts`** — both hounfour-backed synthesis paths called `hounfour.invoke({messages…})`, but the router signature is `invoke(agent, prompt, options)`. Every call would have thrown `BINDING_INVALID` at runtime whenever hounfour was enabled (personality synthesis and agent-chat `generateResponse`). Rewired to the real signature; the persona rides via `InvokeOptions.systemPrompt`.
2. **`src/nft/transfer-listener.ts`** — `onTransferInvalidate` was dropped in the constructor (missing from the stored-config `Pick`), so the Cycle 040 cache-invalidation hook never fired even when configured.
3. **`src/hounfour/jwt-auth.ts`** — `AUDIENCE_MAP` lacked the `byok` endpoint type; `resolveAudience("byok")` returned `undefined`. BYOK rides the invoke surface, so it maps to `loa-finn`.
4. **`src/hounfour/router.ts`** — `'../nft-routing-config.js'` pointed one directory too high (the module lives next to router.ts).

## Related Issues

Closes #154

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/Infrastructure change

## Changes Made

- The four runtime-bug fixes above
- jose v6: `jose.KeyLike` → `CryptoKey` in wallet-auth + siwe-ownership (the repo's established `admin.ts` pattern; KeyLike was removed in jose ≥6.2)
- viem: `PublicClient` fields instantiated with the OP-Stack `base` chain generics (`PublicClient<HttpTransport, typeof base>`) in wallet-auth, chain-config, ownership — the chain's extended block/tx formatters are incompatible with the bare `PublicClient` type
- payment-decision + entropy: untrusted body/context fields narrowed with `typeof` guards instead of `?? ""` (which collapses `unknown` to `{}`)
- dlq: Redis stream field normalized via `String()` before `parseInt` (stream fields arrive as strings at runtime)
- personality-pipeline: redis dep typed as `RedisCommandClient` — what `redis.getClient()` actually returns; the pipeline only uses set/eval/exists
- Misc: `as unknown as` on the non-overlapping casts, documented x402 boundary cast (the verifier does full structural + signature validation), typed substrate test spies, Effect `runPromise` casts + `Exit` narrowing
- **CI ratchet**: deploy workflows' "Compile check" upgraded from `tsc --noCheck --noEmit` (parse-only no-op) to a real `tsc --noEmit`, with the stale comment corrected

## Testing

Describe how you tested these changes:

- [x] Tested with Claude Code locally
- [ ] Ran relevant commands (`/setup`, `/plan-and-analyze`, etc.) — N/A
- [ ] Added/updated tests — type-level changes are guarded by the now-strict tsc gate; the runtime-bug fixes restore paths covered by existing behavior
- [x] All existing tests pass — `pnpm run build` exit 0; vitest 5,083 passed / 255 files. The two failing files are pre-existing on origin/main and environment-specific: `budget-circuit-breaker` requires a non-root runner (as root, `mkdir -p` succeeds on the intentionally-bad `/nonexistent` ledger path so the failure path never triggers), and the `identity-graph` timeout is the known 18 MB graph.json issue that PR #165 addresses.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works — see Testing note
- [x] New and existing tests pass locally (see environmental caveat above)

## Documentation

- [ ] README.md updated (if applicable)
- [ ] CLAUDE.md updated (if applicable)
- [ ] PROCESS.md updated (if applicable)
- [ ] CHANGELOG.md updated (maintainers will review)

## Screenshots (if applicable)

N/A

## Additional Notes

The branch was restarted from latest `main` after PR #259 merged, so this PR contains only this one commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gfmy53nnyuv9cPLwPdPnxL)_